### PR TITLE
Fixing issues with cmake include_directories.

### DIFF
--- a/esma.cmake
+++ b/esma.cmake
@@ -10,7 +10,10 @@ endif()
 
 # Bring in ecbuild
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/@ecbuild/cmake")
+set (BUILD_SHARED_LIBS OFF)
+set (ECBUILD_2_COMPAT_VALUE OFF)
 include (ecbuild_system NO_POLICY_SCOPE)
+
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/check_compiler_support")
 include ("${CMAKE_Fortran_COMPILER_ID}")

--- a/esma_add_library.cmake
+++ b/esma_add_library.cmake
@@ -65,8 +65,8 @@ macro (esma_add_library this)
   set (install_dir include/${this})
   # Export target  include directories for other targets
   target_include_directories(${this} PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR} # stubs
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # stubs
 # modules and copied *.h, *.inc    
     $<BUILD_INTERFACE:${esma_include}/${this}>
     $<INSTALL_INTERFACE:${install_dir}>
@@ -79,9 +79,10 @@ macro (esma_add_library this)
   endif ()
   
   if (ARGS_INCLUDES)
-    target_include_directories(${this} PUBLIC ${ARGS_INCLUDES})
+    target_include_directories(${this} PUBLIC $<BUILD_INTERFACE:${ARGS_INCLUDES}>)
   endif ()
 
+  # The following possibly duplicates logic that is already in the ecbuild layer
   install (DIRECTORY  ${esma_include}/${this}/ DESTINATION include/${this})
 
 endmacro ()


### PR DESCRIPTION
include_directories must be specified differetly for BUILD vs INSTALL.
Further corrections are needed in some components that add_library().