### PR TITLE
Make the F2Py so's executable

### DIFF
--- a/UseF2Py.cmake
+++ b/UseF2Py.cmake
@@ -166,7 +166,7 @@ macro (add_f2py_module _name)
 
   if(NOT (add_f2py_module_DESTINATION MATCHES "^$" OR add_f2py_module_DESTINATION MATCHES ";"))
     # Install the python module
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY_SUFFIX}"
+    install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY_SUFFIX}"
             DESTINATION ${add_f2py_module_DESTINATION})
   endif(NOT (add_f2py_module_DESTINATION MATCHES "^$" OR add_f2py_module_DESTINATION MATCHES ";"))
 


### PR DESCRIPTION
In the CVS model, all the F2Py produced so files are executable.
Apparently, shared object libraries can be executed in some
circumstances:

https://unix.stackexchange.com/questions/40587/why-are-shared-libraries-executable
https://unix.stackexchange.com/questions/223385/why-and-how-are-some-shared-libraries-runnable-as-though-they-are-executables

Are these? Probably not, but I'm trying to get everything identical in
case.