### PR TITLE
Move install directory parallel to build/

### DIFF
--- a/esma.cmake
+++ b/esma.cmake
@@ -1,9 +1,9 @@
 # Most users of this software do not (should not?) have permissions to
 # install in the cmake default of /usr/local (or equiv on other os's).
-# Below, the default is changed to a directory within the build tree
+# Below, the default is changed to a directory parallel to the build tree
 # unless the user explicitly sets CMAKE_INSTALL_PREFIX in the cache.
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "default install path" FORCE )
+    set (CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install" CACHE PATH "default install path" FORCE )
     message(STATUS "*** Setting default install prefix to ${CMAKE_INSTALL_PREFIX}.")
     message(STATUS "*** Override with -DCMAKE_INSTALL_PREFIX=<path>.")
 endif()

--- a/esma.cmake
+++ b/esma.cmake
@@ -1,11 +1,11 @@
 # Most users of this software do not (should not?) have permissions to
 # install in the cmake default of /usr/local (or equiv on other os's).
-# Below, the default is changed to a directory parallel to the build tree
-# unless the user explicitly sets CMAKE_INSTALL_PREFIX in the cache.
+# So, below, we require the user to pass in a CMAKE_INSTALL_PREFIX
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set (CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install" CACHE PATH "default install path" FORCE )
-    message(STATUS "*** Setting default install prefix to ${CMAKE_INSTALL_PREFIX}.")
-    message(STATUS "*** Override with -DCMAKE_INSTALL_PREFIX=<path>.")
+    message(STATUS "*** ERROR ***")
+    message(STATUS "You have not specified an install path for this project.")
+    message(STATUS "*** Please re-run CMake with -DCMAKE_INSTALL_PREFIX=<path>.")
+    message(FATAL_ERROR "Configuration stopped.")
 endif()
 
 # Bring in ecbuild


### PR DESCRIPTION
Per discussion with @pchakraborty, move the install directory to parallel with `build/`. 

The reason is that in the `build/` directory there is a `bin/` directory which we felt could confuse people if (when) we said "Go to the bin directory" or the like.