### PR TITLE
Install automatically generated rc files

### DIFF
--- a/esma_generate_automatic_code.cmake
+++ b/esma_generate_automatic_code.cmake
@@ -21,6 +21,7 @@ macro (new_esma_generate_automatic_code
     )
   add_custom_target (phony_${target} DEPENDS ${generated_files})
   add_dependencies (${target} phony_${target})
+  install(FILES ${rcs_destination}/${rcs} DESTINATION etc)
 
 endmacro ()
 


### PR DESCRIPTION
The `install/etc` directory was missing some the `HISTORY___.rc` files that are automatically generated in `GOCART`, et al.

Add `install` step here to install the files into `install/etc`