### PR TITLE
Fixes #34 - improved ecbuild consistency.

### DIFF
--- a/esma.cmake
+++ b/esma.cmake
@@ -78,6 +78,8 @@ else ()
   find_package (MKL REQUIRED)
 endif ()
 
+option (ESMA_ALLOW_DEPRECATED "suppress warnings about deprecated features" ON)
+
 # Unit testing
 option (PFUNIT "Activate pfunit based tests" OFF)
 if (PFUNIT)

--- a/esma_add_library.cmake
+++ b/esma_add_library.cmake
@@ -52,7 +52,7 @@ macro (esma_add_library this)
     if (NOT ESMA_ALLOW_DEPRECATED)
       ecbuild_warn("DEPENDENCIES is a deprecated option for esma_add_library(); use PUBLIC_LIBS instead")
     endif ()
-    set (ARGS_PUBLIC_LIBS ${ARGS_DEPENDS})
+    set (ARGS_PUBLIC_LIBS ${ARGS_DEPENDENCIES})
   endif ()
 
   # Configure subcomponents.  These can be stubbed and may have a

--- a/esma_add_library.cmake
+++ b/esma_add_library.cmake
@@ -115,8 +115,9 @@ macro (esma_add_library this)
     target_compile_definitions(${this} PRIVATE ${ARGS_PRIVATE_DEFINITIONS})
   endif ()
   if (ARGS_PUBLIC_DEFINITIONS)
-    target_compile_definitions(${this} PRIVATE ${ARGS_PRIVATE_DEFINITIONS})
+    target_compile_definitions(${this} PUBLIC ${ARGS_PUBLIC_DEFINITIONS})
   endif ()
+
   # The following possibly duplicates logic that is already in the ecbuild layer
   install (DIRECTORY  ${esma_include}/${this}/ DESTINATION include/${this})
 

--- a/esma_add_library.cmake
+++ b/esma_add_library.cmake
@@ -22,12 +22,12 @@ macro (esma_add_library this)
     # deprecated in esma (produces explicit warnings)
     SRCS INCLUDES DEPENDENCIES 
     # deprecated in ecbuild
-    PUBLIC_INCLUDES DEPENDS
+    PUBLIC_INCLUDES
     )
   cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   if (ARGS_UNPARSED_ARGUMENTS)
-    ecbuild_warn ("Unrecognized keyword arguments passed to esma_add_library: ${ARGS_UNPARSED_ARGUMENTS}")
+      ecbuild_warn ("Unrecognized keyword arguments passed to esma_add_library: ${ARGS_UNPARSED_ARGUMENTS}")
   endif ()
 
   # Subdirs must exist and should be configured prior to subcomponents.
@@ -37,15 +37,21 @@ macro (esma_add_library this)
 
   # Handle deprecated
   if (ARGS_SRCS)
-    ecbuild_warn("SRCS is a deprecated option for esma_add_library(); use SOURCES instead")
+    if (NOT ESMA_ALLOW_DEPRECATED)
+      ecbuild_warn("SRCS is a deprecated option for esma_add_library(); use SOURCES instead")
+      endif ()
     set (ARGS_SOURCES ${ARGS_SRCS})
   endif ()
   if (ARGS_INCLUDES)
-    ecbuild_warn("SRCS is a deprecated option for esma_add_library(); use target_include_directories instead")
+    if (NOT ESMA_ALLOW_DEPRECATED)
+      ecbuild_warn("SRCS is a deprecated option for esma_add_library(); use target_include_directories instead")
+    endif ()
     set (ARGS_PUBLIC_INCLUDES ${ARGS_INCLUDES})
   endif ()
   if (ARGS_DEPENDENCIES)
-    ecbuild_warn("DEPENDENCIES is a deprecated option for esma_add_library(); use PUBLIC_LIBS instead")
+    if (NOT ESMA_ALLOW_DEPRECATED)
+      ecbuild_warn("DEPENDENCIES is a deprecated option for esma_add_library(); use PUBLIC_LIBS instead")
+    endif ()
     set (ARGS_PUBLIC_LIBS ${ARGS_DEPENDS})
   endif ()
 


### PR DESCRIPTION
Note that packages that use this macro will get warning messages until
they update.   But should be strictly backward compatible with zero-diff in
all fixtures.

Note that this change also expands the esma_add_library() macro a bit.  E.g. one can now pass compiler definitions (e.g., -DMAPL_MODE) on the macro via PUBLIC_DEFINITIONS option.
