### PR TITLE
Fixes #26. Add QUIET to two find_package

### DIFF
--- a/FindBaselibs.cmake
+++ b/FindBaselibs.cmake
@@ -48,8 +48,8 @@ set (INC_HDF ${BASEDIR}/include/hdf)
 set (INC_ESMF ${BASEDIR}/include/esmf)
 
 find_package(GFTL REQUIRED)
-find_package(GFTL_SHARED)
-find_package(FARGPARSE)
+find_package(GFTL_SHARED QUIET)
+find_package(FARGPARSE QUIET)
 
 set (INC_FLAP ${BASEDIR}/include/FLAP)
 set (LIB_FLAP ${BASEDIR}/lib/libflap.a)


### PR DESCRIPTION
We don't need gFTL-Shared or fArgParse yet, so make it `QUIET` if they aren't there.