### PR TITLE
Update Externals.cfg

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ecbuild.git
 local_path = ./@ecbuild
-branch = feature/FindMKL-portability-improvement
+tag = geos/v1.0.1
 protocol = git
 
 [externals_description]


### PR DESCRIPTION
Update to tag `geos/v1.0.1` to avoid CMake 3.17 warning