### PR TITLE
Fixes #61 macro to use Python ACG

### DIFF
--- a/esma_generate_automatic_code.cmake
+++ b/esma_generate_automatic_code.cmake
@@ -1,4 +1,70 @@
-# Generate headers and  resource files for GOCART components
+################################################################################################
+# Automatically generate files from a file that provides specs
+# for the states of a gridde component.
+#
+# Usage:
+#
+#    esma_acg (target specs_file <options>)
+#
+# Options:
+#       IMPORT_SPECS [file]  filename for AddImportSpec() code (default <gc>_Import___.h)
+#       EXPORT_SPECS [file]  filename for AddExportSpec() code (default <gc>_Export___.h)
+#       INTERNAL_SPECS [file]  filename for AddInternalSpec() code (default <gc>_Internal___.h)
+#       GET_POINTERS [file]  filename for GetPointer() code (default <gc>_GetPointer___.h)
+#       GET_POINTERS [file]  filename for GetPointer() code (default <gc>_DeclarePointer___.h)
+#
+################################################################################################
+
+
+macro (esma_acg target specs_file)
+  set (options)
+  set (oneValueArgs  IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS GET_POINTERS DECLARE_POINTERS)
+  # This list must align with oneValueArgs above (for later ZIP_LISTS)
+  set (flags         -i           -x           -p             -g           -d)
+  set (defaults      Import       Export       Internal       GetPointer   DeclarePointer)
+  set (multiValueArgs)
+  cmake_parse_arguments (ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  string (REPLACE "_GridComp" "" component_name ${target})
+
+  if (ARGS_UNPARSED_ARGUMENTS)
+    ecbuild_error ("esma_set_this unparsed arguments: ${ARGS_UNPARSED_ARGUMENTS}")
+  endif ()
+
+  set (generated) # empty unless
+  set (options "")
+
+
+  # Handle oneValueArgs with no value (Python provides default)
+  foreach (opt flag default IN ZIP_LISTS oneValueArgs flags defaults)
+
+    if (ARGS_${opt})
+      string (REPLACE "{component}" component_name fname ${ARGS_${opt}})
+      list (APPEND generated ${fname})
+      list (APPEND options ${flag} ${ARGS_${opt}})
+    elseif (${opt} IN_LIST ARGS_KEYWORDS_MISSING_VALUES)
+      string (REPLACE "{component}" component_name fname ${default})
+      list (APPEND generated ${fname})
+      list (APPEND options ${flag})
+    endif ()
+
+  endforeach ()
+
+  set(generator ${esma_etc}/MAPL/MAPL_GridCompSpecs_ACG.py)
+  add_custom_command (
+    OUTPUT ${generated}
+    COMMAND ${generator} ${CMAKE_CURRENT_SOURCE_DIR}/${specs_file} ${options}
+    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/${specs_file} 
+    DEPENDS ${generator} ${specs_file}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating automatic code for ${specs_file}"
+    )
+  add_custom_target (acg_phony_${target} DEPENDS ${generated})
+  add_dependencies (${target} acg_phony_${target})
+
+endmacro ()
+
+
 
 set (acg_flags -v)
 
@@ -13,7 +79,6 @@ macro (new_esma_generate_automatic_code
     COMMAND ${generator} ${acg_flags} ${flags} ${CMAKE_CURRENT_SOURCE_DIR}/${registry}
     COMMAND ${CMAKE_COMMAND} -E copy ${headers} ${headers_destination}
     COMMAND ${CMAKE_COMMAND} -E copy ${rcs} ${rcs_destination}
-    COMMAND touch foo
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/${registry}
     DEPENDS ${generator}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
  - Enables the use of Python code generator that generates
    include files from a CSV spec file for a grid comp.