### PR TITLE
Additional changes to support MAPL reorg.

### DIFF
--- a/FindBaselibs.cmake
+++ b/FindBaselibs.cmake
@@ -88,13 +88,6 @@ endif ()
 set (NETCDF_LIBRARIES ${NETCDF_LIBRARIES_OLD})
 set (ESMF_LIBRARIES ${ESMF_LIBRARY} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_CXX_LIBRARIES} ${stdcxx} ${libgcc})
 
-# Unit testing
-# option (PFUNIT "Activate pfunit based tests" OFF)
-find_package(PFUNIT QUIET)
-if (PFUNIT_FOUND)
-  add_custom_target(tests COMMAND ${CMAKE_CTEST_COMMAND})
-endif ()
-
 # BASEDIR.rc file does not have the arch
 string(REPLACE "/${CMAKE_SYSTEM_NAME}" "" BASEDIR_WITHOUT_ARCH ${BASEDIR})
 set(BASEDIR_WITHOUT_ARCH ${BASEDIR_WITHOUT_ARCH} CACHE STRING "BASEDIR without arch")

--- a/esma.cmake
+++ b/esma.cmake
@@ -107,7 +107,9 @@ option (ESMA_ALLOW_DEPRECATED "suppress warnings about deprecated features" ON)
 # Baselibs ...
 include (FindBaselibs)
 
-enable_testing()
+# Testing
+include (esma_enable_tests)
+
 set (CMAKE_INSTALL_MESSAGE LAZY)
 
 # This is a "stub" macro to detect building within an ESMA project (for MAPL standalone)

--- a/esma_create_stub_component.cmake
+++ b/esma_create_stub_component.cmake
@@ -1,18 +1,18 @@
-function (esma_create_stub_component srcs module)
+macro (esma_create_stub_component srcs module)
   list (APPEND ${srcs} ${module}.F90)
 
-  find_file (generator
+  find_file (stub_generator
     NAME mapl_stub.pl
     PATHS ${MAPL_SOURCE_DIR}/MAPL_Base ${esma_etc}/MAPL)
 
   add_custom_command (
     OUTPUT ${module}.F90
-    COMMAND ${generator} ${module}Mod > ${module}.F90
-    MAIN_DEPENDENCY ${generator}
+    COMMAND ${stub_generator} ${module}Mod > ${module}.F90
+    MAIN_DEPENDENCY ${stub_generator}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Making component stub for ${module}Mod in ${module}.F90"
     )
   add_custom_target(stub_${module} DEPENDS ${module}.F90)
 
-endfunction ()
+endmacro ()
 

--- a/esma_create_stub_component.cmake
+++ b/esma_create_stub_component.cmake
@@ -1,9 +1,12 @@
 macro (esma_create_stub_component srcs module)
   list (APPEND ${srcs} ${module}.F90)
+  find_file (generator
+    NAME mapl_stub.pl
+    PATHS ${MAPL_SOURCE_DIR}/MAPL_Base ${esma_etc}/MAPL)
   add_custom_command (
     OUTPUT ${module}.F90
-    COMMAND ${MAPL_SOURCE_DIR}/MAPL_Base/mapl_stub.pl ${module}Mod > ${module}.F90
-    MAIN_DEPENDENCY ${MAPL_SOURCE_DIR}/MAPL_Base/mapl_stub.pl
+    COMMAND ${generator} ${module}Mod > ${module}.F90
+    MAIN_DEPENDENCY ${generator}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Making component stub for ${module}Mod in ${module}.F90"
     )

--- a/esma_create_stub_component.cmake
+++ b/esma_create_stub_component.cmake
@@ -1,8 +1,10 @@
-macro (esma_create_stub_component srcs module)
+function (esma_create_stub_component srcs module)
   list (APPEND ${srcs} ${module}.F90)
+
   find_file (generator
     NAME mapl_stub.pl
     PATHS ${MAPL_SOURCE_DIR}/MAPL_Base ${esma_etc}/MAPL)
+
   add_custom_command (
     OUTPUT ${module}.F90
     COMMAND ${generator} ${module}Mod > ${module}.F90
@@ -11,5 +13,6 @@ macro (esma_create_stub_component srcs module)
     COMMENT "Making component stub for ${module}Mod in ${module}.F90"
     )
   add_custom_target(stub_${module} DEPENDS ${module}.F90)
-endmacro ()
+
+endfunction ()
 

--- a/esma_enable_tests.cmake
+++ b/esma_enable_tests.cmake
@@ -1,0 +1,15 @@
+enable_testing()
+find_package(PFUNIT QUIET)
+
+add_custom_target(build-tests)
+add_custom_target(tests
+  COMMAND ${CMAKE_CTEST_COMMAND}
+  EXCLUDE_FROM_ALL)
+add_dependencies(tests build-tests)
+
+# The following forces tests to be built when using "make ctest" even if some targets
+# are EXCLUDE_FROM_ALL
+# From https://stackoverflow.com/questions/733475/cmake-ctest-make-test-doesnt-build-tests/56448477#56448477
+build_command(CTEST_CUSTOM_PRE_TEST TARGET build-tests)
+string(CONFIGURE \"@CTEST_CUSTOM_PRE_TEST@\" CTEST_CUSTOM_PRE_TEST_QUOTED ESCAPE_QUOTES)
+file(WRITE "${CMAKE_BINARY_DIR}/CTestCustom.cmake" "set(CTEST_CUSTOM_PRE_TEST ${CTEST_CUSTOM_PRE_TEST_QUOTED})" "\n")


### PR DESCRIPTION
Necessary because of existing hardwired paths in
ESMA_cmake.