### PR TITLE
Add USE_F2PY Option

### DIFF
--- a/esma.cmake
+++ b/esma.cmake
@@ -119,4 +119,8 @@ endmacro ()
 
 find_package(GitInfo)
 
-find_package(F2PY)
+option(USE_F2PY "Turn on F2PY builds" ON)
+
+if (USE_F2PY)
+   find_package(F2PY)
+endif ()


### PR DESCRIPTION
@nosolls has found that some OSs still have issues with F2PY in his container work. As in, it thinks it can do it, but doesn't work right and the install step fails.

Until I am able to test these myself, for now we provide an option for users to just bypass f2py use all together. The default remains at `ON` so that on places like discover, it still acts as before.