### PR TITLE
Hotfix for more recent CMake

### DIFF
--- a/esma.cmake
+++ b/esma.cmake
@@ -89,7 +89,7 @@ find_package (MPI REQUIRED)
 
 if (APPLE)
   if (DEFINED ENV{MKLROOT})
-    set (MKL_Fortran)
+    set (MKL_Fortran True)
     find_package (MKL REQUIRED)
   else ()
     if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")


### PR DESCRIPTION
It is no longer sufficient to define MKL_Fortran on OS X without giving it a value.