### PR TITLE
Add RELATIVE_PATHS fix for macOS

### DIFF
--- a/osx_extras.cmake
+++ b/osx_extras.cmake
@@ -25,3 +25,14 @@ set (OSX_EXTRA_LIBRARY_PATH $ENV{OSX_EXTRA_LIBRARY_PATH} CACHE PATH "Fill with D
 
 # 4) In order for MKL to work at runtim, this is needed
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# 5) With the advent of shared libraries in GEOS, one needs to symlink install/lib in an experiment
+#    or use this command
+ecbuild_warn(
+   "Setting ENABLE_RELATIVE_RPATHS to FALSE.\n"
+   "This changes LC_RPATH in the executable from:\n"
+   " path @loader_path/../lib\n"
+   "to:\n"
+   " path ${CMAKE_INSTALL_PREFIX}/lib"
+   )
+set (ENABLE_RELATIVE_RPATHS FALSE)


### PR DESCRIPTION
This commit allows for "easy" use of the mom5/mom6 shared libraries when running on macOS. It hard codes in the `install/lib` path into the LC_RPATH in the executable (as visible with `otool -l`). Without this, the LC_RPATH is `@loader_path/../lib` which means if you run the executable in `experiment/scratch/GEOSgcm.x` it is looking for `experiment/lib`. 