### PR TITLE
Fix download for Ubuntu docker images

### DIFF
--- a/DetermineSite.cmake
+++ b/DetermineSite.cmake
@@ -11,7 +11,7 @@ elseif (${BUILD_SITE} MATCHES "pfe" OR ${BUILD_SITE} MATCHES "r[0-9]*i[0-9]*n[0-
 elseif (EXISTS /ford1/share/gmao_SIteam AND EXISTS /ford1/local AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
    set (DETECTED_SITE "GMAO.desktop")
 else ()
-   file(DOWNLOAD http://169.254.169.254/latest/meta-data/instance-id instance-id
+   file(DOWNLOAD http://169.254.169.254/latest/meta-data/instance-id ${CMAKE_CURRENT_BINARY_DIR}/instance-id
       INACTIVITY_TIMEOUT 1.0
       TIMEOUT 1.0
       STATUS DOWNLOAD_STATUS


### PR DESCRIPTION
In testing Ubuntu 20 docker images on CircleCI, my use of `file(DOWNLOAD)` found a laxity in how I called it. This fixes the issue.