### PR TITLE
Fix f2py tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-## [3.1.2] - 2020-08-04 
+## [3.1.3] - 2020-08-07
+
+### Fixed
+
+- Fix for handling f2py tests
+
+## [3.1.2] - 2020-08-04
 
 ### Fixed
 

--- a/esma.cmake
+++ b/esma.cmake
@@ -8,6 +8,10 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     message(STATUS "*** Override with -DCMAKE_INSTALL_PREFIX=<path>.")
 endif()
 
+# FindPython often finds the wrong python (system rather than a python stack
+# provided by GEOS-ESM maintainers). This allows us 
+find_program(Python_EXECUTABLE python python3 python2)
+
 # Bring in ecbuild
 if (IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/ecbuild")
   list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ecbuild/cmake")


### PR DESCRIPTION
Use `find_program` to help CMake use *our* Python and not system.