### PR TITLE
Add CircleCI build for ESMA_cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: gmao/ubuntu20-geos-env-mkl:6.0.13-openmpi_4.0.4-gcc_10.2.0
+    resource_class: xlarge
+    working_directory: /root/project
+    steps:
+      - run:
+          name: "ESMA_cmake branch"
+          command: echo ${CIRCLE_BRANCH}
+      - checkout
+      - run:
+          name: "Checkout GEOSgcm fixture and update ESMA_cmake branch"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}
+            git clone git@github.com:GEOS-ESM/GEOSgcm.git
+            cd GEOSgcm
+            mepo clone
+            mepo develop GEOSgcm_GridComp GEOSgcm_App
+            if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "master" ] && [ "${CIRCLE_BRANCH}" != "main" ]
+            then
+               mepo checkout-if-exists ${CIRCLE_BRANCH}
+            fi
+            mepo status
+      - run:
+          name: "CMake"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm
+            mkdir build
+            cd build
+            cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_BUILD_TYPE=Debug
+      - run:
+          name: "Build"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm/build
+            make -j"$(nproc)" install


### PR DESCRIPTION
Just does a build. I figure an FV3 Standalone run probably isn't necessary as a CMake bug is usually a build-time bug.