### PR TITLE
Update check flags for Intel Debug

### DIFF
--- a/Intel.cmake
+++ b/Intel.cmake
@@ -55,7 +55,7 @@ set (common_Fortran_fpe_flags "${FPE0} ${FP_MODEL_SOURCE} ${HEAPARRAYS} ${NOOLD_
 
 # GEOS Debug
 # ----------
-set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check bounds -check uninit -fp-stack-check -warn unused -init=snan,arrays -save-temps")
+set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check all,noarg_temp_created -fp-stack-check -warn unused -init=snan,arrays -save-temps")
 set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 
 # GEOS Release


### PR DESCRIPTION
Fixes #125.

As reported by @lizziel, Harvard had some issues with `-check bounds -check uninit`. While we could have gone to `-check bounds,uninit` using `-check all` is probably better. But, GEOS apparently uses many, many temp copies in routine calls, so we also add `noarg_temp_created`:

> [no]arg_temp_created
> Determines whether checking occurs for actual arguments copied into temporary storage before routine calls.
