### PR TITLE
Add Changelog Enforcer to ESMA_cmake

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -1,0 +1,16 @@
+name: "Enforce Changelog"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request 
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v1.5.1
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabel: 'Skip Changelog'
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
+
+- Fixed `new_esma_generate_automatic_code` macro to better handle automatically generated files (see https://github.com/GEOS-ESM/GEOSchem_GridComp/issues/108)
+
 ### Removed
 ### Added
+
+- Add changelog enforcer
 
 ## [3.3.1] - 2020-11-23
 


### PR DESCRIPTION
I keep forgetting that we have a `CHANGELOG.md` here. This will prevent that!