### PR TITLE
add __NAGFORTRAN__ definition

### DIFF
--- a/NAG.cmake
+++ b/NAG.cmake
@@ -12,6 +12,7 @@ set (CRAY_POINTER "")
 set (EXTENDED_SOURCE "-132")
 set (FIXED_SOURCE "-fixed")
 
+add_definitions(-D__NAGFORTRAN__)
 ####################################################
 
 # Common Fortran Flags


### PR DESCRIPTION
It is hard to have one code fits all compilers.  We may need this defination in the future to build GEOSgcm with Nag fortran