### PR TITLE
Updates to use Python2 and Python3 at same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+- Added Python2 and Python3 versions of generic Python F2PY macros.
+
 ## [3.3.7] - 2021-03-09
 
 ### Fixed

--- a/FindF2PY2.cmake
+++ b/FindF2PY2.cmake
@@ -1,0 +1,75 @@
+# MAT This code is based, loosely, on the FindF2PY.cmake file from scikit
+#.rst:
+#
+# The purpose of the F2PY –Fortran to Python interface generator– project is to provide a
+# connection between Python and Fortran languages.
+#
+# F2PY is a Python package (with a command line tool f2py and a module f2py2e) that facilitates
+# creating/building Python C/API extension modules that make it possible to call Fortran 77/90/95
+# external subroutines and Fortran 90/95 module subroutines as well as C functions; to access Fortran
+# 77 COMMON blocks and Fortran 90/95 module data, including allocatable arrays from Python.
+#
+# For more information on the F2PY project, see http://www.f2py.com/.
+#
+# The following variables are defined:
+#
+# ::
+#
+#   F2PY2_EXECUTABLE      - absolute path to the F2PY2 executable
+#
+# ::
+#
+#   F2PY2_VERSION_STRING  - the version of F2PY2 found
+#   F2PY2_VERSION_MAJOR   - the F2PY2 major version
+#   F2PY2_VERSION_MINOR   - the F2PY2 minor version
+#   F2PY2_VERSION_PATCH   - the F2PY2 patch version
+#
+#
+# .. note::
+#
+#   By default, the module finds the F2PY2 program associated with the installed NumPy package.
+#
+
+# Path to the f2py executable
+find_package(Python2 COMPONENTS Interpreter)
+
+find_program(F2PY2_EXECUTABLE NAMES "f2py${Python2_VERSION_MAJOR}.${Python2_VERSION_MINOR}"
+                                   "f2py-${Python2_VERSION_MAJOR}.${Python2_VERSION_MINOR}"
+                                   "f2py${Python2_VERSION_MAJOR}"
+                                   "f2py"
+                                   )
+
+if(F2PY2_EXECUTABLE)
+   # extract the version string
+   execute_process(COMMAND "${F2PY2_EXECUTABLE}" -v
+                     OUTPUT_VARIABLE F2PY2_VERSION_STRING
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+   if("${F2PY2_VERSION_STRING}" MATCHES "^([0-9]+)(.([0-9+]))?(.([0-9+]))?$")
+      set(F2PY2_VERSION_MAJOR "${CMAKE_MATCH_1}")
+      set(F2PY2_VERSION_MINOR "${CMAKE_MATCH_3}")
+      set(F2PY2_VERSION_PATCH "${CMAKE_MATCH_5}")
+   endif()
+
+   # Now we need to test if we can actually use f2py2 and what its suffix is
+
+   include(try_f2py2_compile)
+   try_f2py2_compile(
+      ${CMAKE_CURRENT_LIST_DIR}/check_compiler_support/test.F90
+      DETECT_F2PY2_SUFFIX
+      )
+
+endif ()
+
+# handle the QUIET and REQUIRED arguments and set F2PY2_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(F2PY2
+   REQUIRED_VARS F2PY2_EXECUTABLE F2PY2_SUFFIX
+   VERSION_VAR F2PY2_VERSION_STRING
+   )
+
+mark_as_advanced(F2PY2_EXECUTABLE F2PY2_SUFFIX)
+
+if (F2PY2_FOUND)
+   include(UseF2Py2)
+endif ()

--- a/FindF2PY3.cmake
+++ b/FindF2PY3.cmake
@@ -1,0 +1,75 @@
+# MAT This code is based, loosely, on the FindF2PY.cmake file from scikit
+#.rst:
+#
+# The purpose of the F2PY –Fortran to Python interface generator– project is to provide a
+# connection between Python and Fortran languages.
+#
+# F2PY is a Python package (with a command line tool f2py and a module f2py2e) that facilitates
+# creating/building Python C/API extension modules that make it possible to call Fortran 77/90/95
+# external subroutines and Fortran 90/95 module subroutines as well as C functions; to access Fortran
+# 77 COMMON blocks and Fortran 90/95 module data, including allocatable arrays from Python.
+#
+# For more information on the F2PY project, see http://www.f2py.com/.
+#
+# The following variables are defined:
+#
+# ::
+#
+#   F2PY3_EXECUTABLE      - absolute path to the F2PY3 executable
+#
+# ::
+#
+#   F2PY3_VERSION_STRING  - the version of F2PY3 found
+#   F2PY3_VERSION_MAJOR   - the F2PY3 major version
+#   F2PY3_VERSION_MINOR   - the F2PY3 minor version
+#   F2PY3_VERSION_PATCH   - the F2PY3 patch version
+#
+#
+# .. note::
+#
+#   By default, the module finds the F2PY3 program associated with the installed NumPy package.
+#
+
+# Path to the f2py executable
+find_package(Python3 COMPONENTS Interpreter)
+
+find_program(F2PY3_EXECUTABLE NAMES "f2py${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
+                                   "f2py-${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
+                                   "f2py${Python3_VERSION_MAJOR}"
+                                   "f2py"
+                                   )
+
+if(F2PY3_EXECUTABLE)
+   # extract the version string
+   execute_process(COMMAND "${F2PY3_EXECUTABLE}" -v
+                     OUTPUT_VARIABLE F2PY3_VERSION_STRING
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+   if("${F2PY3_VERSION_STRING}" MATCHES "^([0-9]+)(.([0-9+]))?(.([0-9+]))?$")
+      set(F2PY3_VERSION_MAJOR "${CMAKE_MATCH_1}")
+      set(F2PY3_VERSION_MINOR "${CMAKE_MATCH_3}")
+      set(F2PY3_VERSION_PATCH "${CMAKE_MATCH_5}")
+   endif()
+
+   # Now we need to test if we can actually use f2py and what its suffix is
+
+   include(try_f2py3_compile)
+   try_f2py3_compile(
+      ${CMAKE_CURRENT_LIST_DIR}/check_compiler_support/test.F90
+      DETECT_F2PY3_SUFFIX
+      )
+
+endif ()
+
+# handle the QUIET and REQUIRED arguments and set F2PY3_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(F2PY3
+   REQUIRED_VARS F2PY3_EXECUTABLE F2PY3_SUFFIX
+   VERSION_VAR F2PY3_VERSION_STRING
+   )
+
+mark_as_advanced(F2PY3_EXECUTABLE F2PY3_SUFFIX)
+
+if (F2PY3_FOUND)
+   include(UseF2Py3)
+endif ()

--- a/UseF2Py2.cmake
+++ b/UseF2Py2.cmake
@@ -1,0 +1,209 @@
+# +-----------------------------------------------------------------------------+
+# |   Copyright (C) 2011-2015                                                   |
+# |   Original by Marcel Loose (loose <at> astron.nl) 2011-2013                 |
+# |   Modified by Chris Kerr (chris.kerr <at> mykolab.ch) 2013-2015             |
+# |                                                                             |
+# |   This program is free software; you can redistribute it and/or modify      |
+# |   it under the terms of the GNU General Public License as published by      |
+# |   the Free Software Foundation; either version 2 of the License, or         |
+# |   (at your option) any later version.                                       |
+# |                                                                             |
+# |   This program is distributed in the hope that it will be useful,           |
+# |   but WITHOUT ANY WARRANTY; without even the implied warranty of            |
+# |   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             |
+# |   GNU General Public License for more details.                              |
+# |                                                                             |
+# |   You should have received a copy of the GNU General Public License         |
+# |   along with this program; if not, write to the                             |
+# |   Free Software Foundation, Inc.,                                           |
+# |   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.                 |
+# +-----------------------------------------------------------------------------+
+
+## -----------------------------------------------------------------------------
+## Macro to generate a Python2 interface module from one or more Fortran sources
+##
+## Usage: add_f2py2_module(<module-name> SOURCES <src1>..<srcN> DESTINATION <install-dir> ONLY <list>)
+##
+macro (add_f2py2_module _name)
+
+  # Parse arguments.
+  set (options USE_MPI USE_OPENMP DOUBLE_PRECISION)
+  set (oneValueArgs DESTINATION)
+  set (multiValueArgs SOURCES ONLY LIBRARIES INCLUDEDIRS)
+  cmake_parse_arguments(add_f2py2_module "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+  set(only_list ${add_f2py2_module_ONLY})
+  if (only_list)
+     set(_only "only:")
+     list(APPEND _only ${add_f2py2_module_ONLY})
+     list(APPEND _only ":")
+  else ()
+    set (_only "")
+  endif()
+    
+  # Sanity checks.
+  if(add_f2py2_module_SOURCES MATCHES "^$")
+    message(FATAL_ERROR "add_f2py2_module: no source files specified")
+  endif(add_f2py2_module_SOURCES MATCHES "^$")
+
+  # Get the compiler-id and map it to compiler vendor as used by f2py2.
+  # Currently, we only check for GNU, but this can easily be extended. 
+  # Cache the result, so that we only need to check once.
+  if(NOT F2PY2_FCOMPILER)
+    if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+      if(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+        set(_fcompiler "gnu95")
+      else(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+        set(_fcompiler "gnu")
+      endif(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+    elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+      set(_fcompiler "intelem")
+    else(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+      set(_fcompiler "F2PY2_FCOMPILER-NOTFOUND")
+    endif(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    set(F2PY2_FCOMPILER ${_fcompiler} CACHE STRING
+      "F2PY2: Fortran compiler type by vendor" FORCE)
+    if(NOT F2PY2_FCOMPILER)
+      message(STATUS "[F2PY2]: Could not determine Fortran compiler type. "
+                     "Troubles ahead!")
+    endif(NOT F2PY2_FCOMPILER)
+  endif(NOT F2PY2_FCOMPILER)
+
+  # Set f2py2 compiler options: compiler vendor and path to Fortran77/90 compiler.
+  if(F2PY2_FCOMPILER)
+
+     set(F2PY2_Fortran_FLAGS)
+
+     ###########################################################################
+     # # If you really want to pass in the flags used by the rest of the model #
+     # # this is how. But I don't think we want to do this                     #
+     # if (CMAKE_BUILD_TYPE MATCHES Release)                                   #
+     #    set(F2PY2_Fortran_FLAGS ${CMAKE_Fortran_FLAGS_RELEASE})               #
+     # elseif(CMAKE_BUILD_TYPE MATCHES Debug)                                  #
+     #    set(F2PY2_Fortran_FLAGS ${CMAKE_Fortran_FLAGS_DEBUG})                 #
+     # endif()                                                                 #
+     # separate_arguments(F2PY2_Fortran_FLAGS)                                  #
+     ###########################################################################
+
+    if (${add_f2py2_module_USE_OPENMP})
+       list(APPEND F2PY2_Fortran_FLAGS ${OpenMP_Fortran_FLAGS})
+    endif()
+
+    if (${add_f2py2_module_DOUBLE_PRECISION})
+       list(APPEND F2PY2_Fortran_FLAGS ${FREAL8})
+    endif()
+
+    #message(STATUS "${_name} F2PY2_Fortran_FLAGS ${F2PY2_Fortran_FLAGS}")
+
+    set(_fcompiler_opts "--fcompiler=${F2PY2_FCOMPILER}")
+    list(APPEND _fcompiler_opts "--f77exec=${CMAKE_Fortran_COMPILER}" "--f77flags='${F2PY2_Fortran_FLAGS}'")
+    if(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+       list(APPEND _fcompiler_opts "--f90exec=${CMAKE_Fortran_COMPILER}" "--f90flags='${F2PY2_Fortran_FLAGS}'")
+    endif(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+  endif(F2PY2_FCOMPILER)
+
+  # Make the source filenames absolute.
+  set(_abs_srcs)
+  foreach(_src ${add_f2py2_module_SOURCES})
+    get_filename_component(_abs_src ${_src} ABSOLUTE)
+    list(APPEND _abs_srcs ${_abs_src})
+  endforeach(_src ${add_f2py2_module_SOURCES})
+
+  # Get a list of the include directories.
+  # The f2py2 --include_paths option, used when generating a signature file,
+  # needs a colon-separated list. The f2py2 -I option, used when compiling
+  # the sources, must be repeated for every include directory.
+  #get_directory_property(_inc_dirs INCLUDE_DIRECTORIES)
+
+  set(_inc_opts)
+  set(_lib_opts)
+  set(_inc_dirs)
+  foreach(_dir ${add_f2py2_module_INCLUDEDIRS})
+    list(APPEND _inc_opts "-I${_dir}")
+    list(APPEND _lib_opts "-L${_dir}")
+    list(APPEND _inc_dirs "${_dir}")
+  endforeach(_dir)
+  string(REPLACE ";" ":" _inc_paths "${_inc_dirs}")
+
+  set(_libs_opts)
+  foreach(_lib ${add_f2py2_module_LIBRARIES})
+     # MAT This is hacky, but so is this whole code
+     #     On darwin, esmf is a full path libesmf.a and
+     #     not esmf_fullylinked. For now, if libesmf.a
+     #     is passed down, replace with esmf
+     if (_lib MATCHES "esmf\.a")
+        set (_lib esmf)
+     endif ()
+     list(APPEND _lib_opts "-l${_lib}")
+  endforeach(_lib)
+
+  if ( ${add_f2py2_module_USE_MPI})
+     foreach (lib ${MPI_Fortran_LIBRARIES})
+        get_filename_component(lib_dir ${lib} DIRECTORY)
+        list(APPEND _lib_opts "-L${lib_dir}")
+
+        get_filename_component(lib_name ${lib} NAME)
+        string(REGEX MATCH "lib(.*)(${CMAKE_SHARED_LIBRARY_SUFFIX}|${CMAKE_STATIC_LIBRARY_SUFFIX})" BOBO ${lib_name})
+        set(short_lib_name "${CMAKE_MATCH_1}")
+        list(APPEND _lib_opts "-l${short_lib_name}")
+     endforeach ()
+  endif ()
+
+  if ( ${add_f2py2_module_USE_OPENMP})
+     foreach (lib ${OpenMP_Fortran_LIBRARIES})
+        get_filename_component(lib_dir ${lib} DIRECTORY)
+        list(APPEND _lib_opts "-L${lib_dir}")
+
+        get_filename_component(lib_name ${lib} NAME)
+        string(REGEX MATCH "lib(.*)(${CMAKE_SHARED_LIBRARY_SUFFIX}|${CMAKE_STATIC_LIBRARY_SUFFIX})" BOBO ${lib_name})
+        set(short_lib_name "${CMAKE_MATCH_1}")
+        list(APPEND _lib_opts "-l${short_lib_name}")
+     endforeach()
+  endif ()
+
+  # This is an ugly hack but the MAM optics f2py2 required it. The
+  # fortran is compiled -r8 but python doesn't know that. Thus, you have
+  # to let python know that "real" is actually "double". The way to do
+  # this according to the internet is to add a dotfile with this junk in
+  # it to allow for this. It's possible it's not correct, but it seem to
+  # let things run
+  if(${add_f2py2_module_DOUBLE_PRECISION})
+     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/.f2py2_f2cmap "{'real':{'':'double'},'integer':{'':'long'},'real*8':{'':'double'},'complex':{'':'complex_double'}}")
+  endif()
+
+  # Define the command to generate the Fortran to Python2 interface module. The
+  # output will be a shared library that can be imported by python.
+  if ( "${add_f2py2_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
+    add_custom_command(OUTPUT "${_name}${F2PY2_SUFFIX}"
+      COMMAND ${F2PY2_EXECUTABLE} --quiet -m ${_name}
+              --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py2-${_name}"
+              ${_fcompiler_opts} ${_inc_opts} -c ${_abs_srcs} &> /dev/null
+      DEPENDS ${add_f2py2_module_SOURCES}
+      COMMENT "[F2PY2] Building Fortran to Python2 interface module ${_name}")
+  else ( "${add_f2py2_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
+    add_custom_command(OUTPUT "${_name}${F2PY2_SUFFIX}"
+      COMMAND ${F2PY2_EXECUTABLE} --quiet -m ${_name} -h ${_name}.pyf
+              --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py2-${_name}"
+              --include-paths ${_inc_paths} --overwrite-signature ${_abs_srcs} &> /dev/null
+      COMMAND ${F2PY2_EXECUTABLE} --quiet -m ${_name}
+              --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py2-${_name}"
+              -c "${CMAKE_CURRENT_BINARY_DIR}/f2py2-${_name}/${_name}.pyf"
+              ${_fcompiler_opts} ${_inc_opts} ${_lib_opts} ${_abs_srcs} ${_lib_opts} ${_only} &> /dev/null
+      DEPENDS ${add_f2py2_module_SOURCES}
+      COMMENT "[F2PY2] Building Fortran to Python2 interface module ${_name}")
+  endif ( "${add_f2py2_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
+  
+
+
+  # Add a custom target <name> to trigger the generation of the python module.
+  add_custom_target(${_name} ALL DEPENDS "${_name}${F2PY2_SUFFIX}")
+
+  if(NOT (add_f2py2_module_DESTINATION MATCHES "^$" OR add_f2py2_module_DESTINATION MATCHES ";"))
+    # Install the python module
+    install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY2_SUFFIX}"
+            DESTINATION ${add_f2py2_module_DESTINATION})
+  endif(NOT (add_f2py2_module_DESTINATION MATCHES "^$" OR add_f2py2_module_DESTINATION MATCHES ";"))
+
+
+endmacro (add_f2py2_module)
+

--- a/UseF2Py3.cmake
+++ b/UseF2Py3.cmake
@@ -1,0 +1,209 @@
+# +-----------------------------------------------------------------------------+
+# |   Copyright (C) 2011-2015                                                   |
+# |   Original by Marcel Loose (loose <at> astron.nl) 2011-2013                 |
+# |   Modified by Chris Kerr (chris.kerr <at> mykolab.ch) 2013-2015             |
+# |                                                                             |
+# |   This program is free software; you can redistribute it and/or modify      |
+# |   it under the terms of the GNU General Public License as published by      |
+# |   the Free Software Foundation; either version 2 of the License, or         |
+# |   (at your option) any later version.                                       |
+# |                                                                             |
+# |   This program is distributed in the hope that it will be useful,           |
+# |   but WITHOUT ANY WARRANTY; without even the implied warranty of            |
+# |   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             |
+# |   GNU General Public License for more details.                              |
+# |                                                                             |
+# |   You should have received a copy of the GNU General Public License         |
+# |   along with this program; if not, write to the                             |
+# |   Free Software Foundation, Inc.,                                           |
+# |   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.                 |
+# +-----------------------------------------------------------------------------+
+
+## -----------------------------------------------------------------------------
+## Macro to generate a Python3 interface module from one or more Fortran sources
+##
+## Usage: add_f2py3_module(<module-name> SOURCES <src1>..<srcN> DESTINATION <install-dir> ONLY <list>)
+##
+macro (add_f2py3_module _name)
+
+  # Parse arguments.
+  set (options USE_MPI USE_OPENMP DOUBLE_PRECISION)
+  set (oneValueArgs DESTINATION)
+  set (multiValueArgs SOURCES ONLY LIBRARIES INCLUDEDIRS)
+  cmake_parse_arguments(add_f2py3_module "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+  set(only_list ${add_f2py3_module_ONLY})
+  if (only_list)
+     set(_only "only:")
+     list(APPEND _only ${add_f2py3_module_ONLY})
+     list(APPEND _only ":")
+  else ()
+    set (_only "")
+  endif()
+    
+  # Sanity checks.
+  if(add_f2py3_module_SOURCES MATCHES "^$")
+    message(FATAL_ERROR "add_f2py3_module: no source files specified")
+  endif(add_f2py3_module_SOURCES MATCHES "^$")
+
+  # Get the compiler-id and map it to compiler vendor as used by f2py3.
+  # Currently, we only check for GNU, but this can easily be extended. 
+  # Cache the result, so that we only need to check once.
+  if(NOT F2PY3_FCOMPILER)
+    if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+      if(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+        set(_fcompiler "gnu95")
+      else(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+        set(_fcompiler "gnu")
+      endif(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+    elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+      set(_fcompiler "intelem")
+    else(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+      set(_fcompiler "F2PY3_FCOMPILER-NOTFOUND")
+    endif(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    set(F2PY3_FCOMPILER ${_fcompiler} CACHE STRING
+      "F2PY3: Fortran compiler type by vendor" FORCE)
+    if(NOT F2PY3_FCOMPILER)
+      message(STATUS "[F2PY3]: Could not determine Fortran compiler type. "
+                     "Troubles ahead!")
+    endif(NOT F2PY3_FCOMPILER)
+  endif(NOT F2PY3_FCOMPILER)
+
+  # Set f2py3 compiler options: compiler vendor and path to Fortran77/90 compiler.
+  if(F2PY3_FCOMPILER)
+
+     set(F2PY3_Fortran_FLAGS)
+
+     ###########################################################################
+     # # If you really want to pass in the flags used by the rest of the model #
+     # # this is how. But I don't think we want to do this                     #
+     # if (CMAKE_BUILD_TYPE MATCHES Release)                                   #
+     #    set(F2PY3_Fortran_FLAGS ${CMAKE_Fortran_FLAGS_RELEASE})               #
+     # elseif(CMAKE_BUILD_TYPE MATCHES Debug)                                  #
+     #    set(F2PY3_Fortran_FLAGS ${CMAKE_Fortran_FLAGS_DEBUG})                 #
+     # endif()                                                                 #
+     # separate_arguments(F2PY3_Fortran_FLAGS)                                  #
+     ###########################################################################
+
+    if (${add_f2py3_module_USE_OPENMP})
+       list(APPEND F2PY3_Fortran_FLAGS ${OpenMP_Fortran_FLAGS})
+    endif()
+
+    if (${add_f2py3_module_DOUBLE_PRECISION})
+       list(APPEND F2PY3_Fortran_FLAGS ${FREAL8})
+    endif()
+
+    #message(STATUS "${_name} F2PY3_Fortran_FLAGS ${F2PY3_Fortran_FLAGS}")
+
+    set(_fcompiler_opts "--fcompiler=${F2PY3_FCOMPILER}")
+    list(APPEND _fcompiler_opts "--f77exec=${CMAKE_Fortran_COMPILER}" "--f77flags='${F2PY3_Fortran_FLAGS}'")
+    if(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+       list(APPEND _fcompiler_opts "--f90exec=${CMAKE_Fortran_COMPILER}" "--f90flags='${F2PY3_Fortran_FLAGS}'")
+    endif(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
+  endif(F2PY3_FCOMPILER)
+
+  # Make the source filenames absolute.
+  set(_abs_srcs)
+  foreach(_src ${add_f2py3_module_SOURCES})
+    get_filename_component(_abs_src ${_src} ABSOLUTE)
+    list(APPEND _abs_srcs ${_abs_src})
+  endforeach(_src ${add_f2py3_module_SOURCES})
+
+  # Get a list of the include directories.
+  # The f2py3 --include_paths option, used when generating a signature file,
+  # needs a colon-separated list. The f2py3 -I option, used when compiling
+  # the sources, must be repeated for every include directory.
+  #get_directory_property(_inc_dirs INCLUDE_DIRECTORIES)
+
+  set(_inc_opts)
+  set(_lib_opts)
+  set(_inc_dirs)
+  foreach(_dir ${add_f2py3_module_INCLUDEDIRS})
+    list(APPEND _inc_opts "-I${_dir}")
+    list(APPEND _lib_opts "-L${_dir}")
+    list(APPEND _inc_dirs "${_dir}")
+  endforeach(_dir)
+  string(REPLACE ";" ":" _inc_paths "${_inc_dirs}")
+
+  set(_libs_opts)
+  foreach(_lib ${add_f2py3_module_LIBRARIES})
+     # MAT This is hacky, but so is this whole code
+     #     On darwin, esmf is a full path libesmf.a and
+     #     not esmf_fullylinked. For now, if libesmf.a
+     #     is passed down, replace with esmf
+     if (_lib MATCHES "esmf\.a")
+        set (_lib esmf)
+     endif ()
+     list(APPEND _lib_opts "-l${_lib}")
+  endforeach(_lib)
+
+  if ( ${add_f2py3_module_USE_MPI})
+     foreach (lib ${MPI_Fortran_LIBRARIES})
+        get_filename_component(lib_dir ${lib} DIRECTORY)
+        list(APPEND _lib_opts "-L${lib_dir}")
+
+        get_filename_component(lib_name ${lib} NAME)
+        string(REGEX MATCH "lib(.*)(${CMAKE_SHARED_LIBRARY_SUFFIX}|${CMAKE_STATIC_LIBRARY_SUFFIX})" BOBO ${lib_name})
+        set(short_lib_name "${CMAKE_MATCH_1}")
+        list(APPEND _lib_opts "-l${short_lib_name}")
+     endforeach ()
+  endif ()
+
+  if ( ${add_f2py3_module_USE_OPENMP})
+     foreach (lib ${OpenMP_Fortran_LIBRARIES})
+        get_filename_component(lib_dir ${lib} DIRECTORY)
+        list(APPEND _lib_opts "-L${lib_dir}")
+
+        get_filename_component(lib_name ${lib} NAME)
+        string(REGEX MATCH "lib(.*)(${CMAKE_SHARED_LIBRARY_SUFFIX}|${CMAKE_STATIC_LIBRARY_SUFFIX})" BOBO ${lib_name})
+        set(short_lib_name "${CMAKE_MATCH_1}")
+        list(APPEND _lib_opts "-l${short_lib_name}")
+     endforeach()
+  endif ()
+
+  # This is an ugly hack but the MAM optics f2py3 required it. The
+  # fortran is compiled -r8 but python doesn't know that. Thus, you have
+  # to let python know that "real" is actually "double". The way to do
+  # this according to the internet is to add a dotfile with this junk in
+  # it to allow for this. It's possible it's not correct, but it seem to
+  # let things run
+  if(${add_f2py3_module_DOUBLE_PRECISION})
+     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/.f2py3_f2cmap "{'real':{'':'double'},'integer':{'':'long'},'real*8':{'':'double'},'complex':{'':'complex_double'}}")
+  endif()
+
+  # Define the command to generate the Fortran to Python3 interface module. The
+  # output will be a shared library that can be imported by python.
+  if ( "${add_f2py3_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
+    add_custom_command(OUTPUT "${_name}${F2PY3_SUFFIX}"
+      COMMAND ${F2PY3_EXECUTABLE} --quiet -m ${_name}
+              --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py3-${_name}"
+              ${_fcompiler_opts} ${_inc_opts} -c ${_abs_srcs} &> /dev/null
+      DEPENDS ${add_f2py3_module_SOURCES}
+      COMMENT "[F2PY3] Building Fortran to Python3 interface module ${_name}")
+  else ( "${add_f2py3_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
+    add_custom_command(OUTPUT "${_name}${F2PY3_SUFFIX}"
+      COMMAND ${F2PY3_EXECUTABLE} --quiet -m ${_name} -h ${_name}.pyf
+              --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py3-${_name}"
+              --include-paths ${_inc_paths} --overwrite-signature ${_abs_srcs} &> /dev/null
+      COMMAND ${F2PY3_EXECUTABLE} --quiet -m ${_name}
+              --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py3-${_name}"
+              -c "${CMAKE_CURRENT_BINARY_DIR}/f2py3-${_name}/${_name}.pyf"
+              ${_fcompiler_opts} ${_inc_opts} ${_lib_opts} ${_abs_srcs} ${_lib_opts} ${_only} &> /dev/null
+      DEPENDS ${add_f2py3_module_SOURCES}
+      COMMENT "[F2PY3] Building Fortran to Python3 interface module ${_name}")
+  endif ( "${add_f2py3_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
+  
+
+
+  # Add a custom target <name> to trigger the generation of the python module.
+  add_custom_target(${_name} ALL DEPENDS "${_name}${F2PY3_SUFFIX}")
+
+  if(NOT (add_f2py3_module_DESTINATION MATCHES "^$" OR add_f2py3_module_DESTINATION MATCHES ";"))
+    # Install the python module
+    install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY3_SUFFIX}"
+            DESTINATION ${add_f2py3_module_DESTINATION})
+  endif(NOT (add_f2py3_module_DESTINATION MATCHES "^$" OR add_f2py3_module_DESTINATION MATCHES ";"))
+
+
+endmacro (add_f2py3_module)
+

--- a/check_compiler_support/try_f2py2_compile.cmake
+++ b/check_compiler_support/try_f2py2_compile.cmake
@@ -1,0 +1,39 @@
+# Used to determine whether compiler is able to compile and/or run a
+# given snippet of source.  Useful for compiler bug workarounds and
+# unsupported features.
+
+macro (try_f2py2_compile file var)
+
+   if (NOT CMAKE_REQUIRED_QUIET)
+      message (STATUS "Performing Test ${var}")
+   endif ()
+
+   set( _f2py2_check_bindir "${CMAKE_BINARY_DIR}/f2py2_tmp")
+   file(MAKE_DIRECTORY ${_f2py2_check_bindir})
+
+   execute_process(
+      COMMAND ${F2PY2_EXECUTABLE} -m test_ -c ${file}
+      WORKING_DIRECTORY ${_f2py2_check_bindir}
+      RESULT_VARIABLE result
+      OUTPUT_QUIET
+      ERROR_QUIET
+      )
+
+   if (result EQUAL 0)
+      file(GLOB F2PY2_TEST_OUTPUT_FILE ${_f2py2_check_bindir}/*.so)
+
+      get_filename_component(F2PY2_FOUND_EXTENSION ${F2PY2_TEST_OUTPUT_FILE} EXT)
+
+      set(F2PY2_SUFFIX ${F2PY2_FOUND_EXTENSION} CACHE STRING "f2py2 suffix")
+      message(STATUS "Setting F2PY2_SUFFIX to ${F2PY2_SUFFIX}")
+      if (NOT CMAKE_REQUIRED_QUIET)
+         message(STATUS "Performing Test ${var}: SUCCESS")
+      endif ()
+   else ()
+      if (NOT CMAKE_REQUIRED_QUIET)
+         message(STATUS "Performing Test ${var}: FAILURE")
+      endif ()
+      message(WARNING "Test f2py2 compile using ${F2PY2_EXECUTABLE} failed. F2PY2 modules will not be built. This usually indicates an incomplete Python/numpy installation.")
+   endif ()
+
+endmacro (try_f2py2_compile)

--- a/check_compiler_support/try_f2py3_compile.cmake
+++ b/check_compiler_support/try_f2py3_compile.cmake
@@ -1,0 +1,39 @@
+# Used to determine whether compiler is able to compile and/or run a
+# given snippet of source.  Useful for compiler bug workarounds and
+# unsupported features.
+
+macro (try_f2py3_compile file var)
+
+   if (NOT CMAKE_REQUIRED_QUIET)
+      message (STATUS "Performing Test ${var}")
+   endif ()
+
+   set( _f2py3_check_bindir "${CMAKE_BINARY_DIR}/f2py3_tmp")
+   file(MAKE_DIRECTORY ${_f2py3_check_bindir})
+
+   execute_process(
+      COMMAND ${F2PY3_EXECUTABLE} -m test_ -c ${file}
+      WORKING_DIRECTORY ${_f2py3_check_bindir}
+      RESULT_VARIABLE result
+      OUTPUT_QUIET
+      ERROR_QUIET
+      )
+
+   if (result EQUAL 0)
+      file(GLOB F2PY3_TEST_OUTPUT_FILE ${_f2py3_check_bindir}/*.so)
+
+      get_filename_component(F2PY3_FOUND_EXTENSION ${F2PY3_TEST_OUTPUT_FILE} EXT)
+
+      set(F2PY3_SUFFIX ${F2PY3_FOUND_EXTENSION} CACHE STRING "f2py3 suffix")
+      message(STATUS "Setting F2PY3_SUFFIX to ${F2PY3_SUFFIX}")
+      if (NOT CMAKE_REQUIRED_QUIET)
+         message(STATUS "Performing Test ${var}: SUCCESS")
+      endif ()
+   else ()
+      if (NOT CMAKE_REQUIRED_QUIET)
+         message(STATUS "Performing Test ${var}: FAILURE")
+      endif ()
+      message(WARNING "Test f2py3 compile using ${F2PY3_EXECUTABLE} failed. F2PY3 modules will not be built. This usually indicates an incomplete Python/numpy installation.")
+   endif ()
+
+endmacro (try_f2py3_compile)

--- a/esma.cmake
+++ b/esma.cmake
@@ -8,10 +8,6 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     message(STATUS "*** Override with -DCMAKE_INSTALL_PREFIX=<path>.")
 endif()
 
-# FindPython often finds the wrong python (system rather than a python stack
-# provided by GEOS-ESM maintainers). This allows us 
-find_program(Python_EXECUTABLE python python3 python2)
-
 # Bring in ecbuild
 if (IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/ecbuild")
   list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ecbuild/cmake")

--- a/esma.cmake
+++ b/esma.cmake
@@ -38,9 +38,12 @@ include (esma_add_library)
 include (esma_generate_automatic_code)
 include (esma_create_stub_component)
 include (esma_fortran_generator_list)
-include (esma_find_python_module)
-include (esma_check_python_module)
-include (esma_add_f2py_module)
+include (esma_find_python2_module)
+include (esma_check_python2_module)
+include (esma_find_python3_module)
+include (esma_check_python3_module)
+include (esma_add_f2py2_module)
+include (esma_add_f2py3_module)
 
 find_package(ImageMagick)
 if (NOT ImageMagick_FOUND)
@@ -142,10 +145,6 @@ endmacro ()
 find_package(GitInfo)
 
 option(USE_F2PY "Turn on F2PY builds" ON)
-
-if (USE_F2PY)
-   find_package(F2PY)
-endif ()
 
 # ecbuild by default puts modules in build-dir/module. This can cause issues if same-named modules
 # are in two directories that aren't using esma_add_library(). This sets the the value to

--- a/esma_add_f2py2_module.cmake
+++ b/esma_add_f2py2_module.cmake
@@ -1,0 +1,10 @@
+macro (esma_add_f2py2_module name)
+
+  add_f2py2_module (${name} ${ARGN})
+
+  add_test (
+    NAME test_${name}
+    COMMAND ${Python2_EXECUTABLE} -c "import ${name}"
+    )
+    
+endmacro ()

--- a/esma_add_f2py2_module.cmake
+++ b/esma_add_f2py2_module.cmake
@@ -2,9 +2,18 @@ macro (esma_add_f2py2_module name)
 
   add_f2py2_module (${name} ${ARGN})
 
+  set(UNIT_TEST test_${name})
   add_test (
-    NAME test_${name}
-    COMMAND ${Python2_EXECUTABLE} -c "import ${name}"
-    )
-    
+     NAME ${UNIT_TEST}
+     COMMAND ${Python2_EXECUTABLE} -c "import ${name}"
+     )
+
+  add_custom_command(
+     TARGET ${name}
+     COMMENT "Running Python2 import test on ${name}"
+     POST_BUILD
+     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+     COMMAND ${Python2_EXECUTABLE} -c "import ${name}"
+     )
+
 endmacro ()

--- a/esma_add_f2py3_module.cmake
+++ b/esma_add_f2py3_module.cmake
@@ -1,0 +1,10 @@
+macro (esma_add_f2py3_module name)
+
+  add_f2py3_module (${name} ${ARGN})
+
+  add_test (
+    NAME test_${name}
+    COMMAND ${Python3_EXECUTABLE} -c "import ${name}"
+    )
+    
+endmacro ()

--- a/esma_add_f2py3_module.cmake
+++ b/esma_add_f2py3_module.cmake
@@ -2,9 +2,18 @@ macro (esma_add_f2py3_module name)
 
   add_f2py3_module (${name} ${ARGN})
 
+  set(UNIT_TEST test_${name})
   add_test (
-    NAME test_${name}
-    COMMAND ${Python3_EXECUTABLE} -c "import ${name}"
-    )
-    
+     NAME ${UNIT_TEST}
+     COMMAND ${Python3_EXECUTABLE} -c "import ${name}"
+     )
+
+  add_custom_command(
+     TARGET ${name}
+     COMMENT "Running Python3 import test on ${name}"
+     POST_BUILD
+     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+     COMMAND ${Python3_EXECUTABLE} -c "import ${name}"
+     )
+
 endmacro ()

--- a/esma_add_f2py_module.cmake
+++ b/esma_add_f2py_module.cmake
@@ -2,9 +2,18 @@ macro (esma_add_f2py_module name)
 
   add_f2py_module (${name} ${ARGN})
 
+  set(UNIT_TEST test_${name})
   add_test (
-    NAME test_${name}
-    COMMAND ${Python_EXECUTABLE} -c "import ${name}"
-    )
-    
+     NAME ${UNIT_TEST}
+     COMMAND ${Python_EXECUTABLE} -c "import ${name}"
+     )
+
+  add_custom_command(
+     TARGET ${name}
+     COMMENT "Running Python import test on ${name}"
+     POST_BUILD
+     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+     COMMAND ${Python_EXECUTABLE} -c "import ${name}"
+     )
+
 endmacro ()

--- a/esma_check_python2_module.cmake
+++ b/esma_check_python2_module.cmake
@@ -1,0 +1,15 @@
+#
+# Usage:  esma_check_python2_module(<module>)
+#
+# Adapted from
+# Citation: https://cmake.org/pipermail/cmake/2011-January/041666.html
+# Mark Moll
+
+function(esma_check_python2_module module)
+
+  add_test (check_python2_${module}
+    COMMAND "${Python2_EXECUTABLE}" "-c" 
+    "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+    )
+
+endfunction (esma_check_python2_module)

--- a/esma_check_python3_module.cmake
+++ b/esma_check_python3_module.cmake
@@ -1,0 +1,15 @@
+#
+# Usage:  esma_check_python3_module(<module>)
+#
+# Adapted from
+# Citation: https://cmake.org/pipermail/cmake/2011-January/041666.html
+# Mark Moll
+
+function(esma_check_python3_module module)
+
+  add_test (check_python3_${module}
+    COMMAND "${Python3_EXECUTABLE}" "-c" 
+    "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+    )
+
+endfunction (esma_check_python3_module)

--- a/esma_find_python2_module.cmake
+++ b/esma_find_python2_module.cmake
@@ -1,0 +1,32 @@
+#
+# Usage:  esma_find_python2_module(<module> [REQUIRED])
+#
+
+# Citation: https://cmake.org/pipermail/cmake/2011-January/041666.html
+# Mark Moll
+
+function(esma_find_python2_module module)
+  string(TOUPPER ${module} module_upper)
+  if(NOT PY2_${module_upper})
+    if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
+      set(PY2_${module}_FIND_REQUIRED TRUE)
+    endif()
+    # A module's location is usually a directory, but for binary modules
+    # it's a .so file.
+    execute_process(COMMAND "${Python2_EXECUTABLE}" "-c" 
+      "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+      RESULT_VARIABLE _${module}_status 
+      OUTPUT_VARIABLE _${module}_location
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _${module}_status)
+      set(PY2_${module_upper} ${_${module}_location} CACHE STRING 
+	"Location of Python2 module ${module}")
+    endif(NOT _${module}_status)
+  endif(NOT PY2_${module_upper})
+  find_package_handle_standard_args(PY2_${module} DEFAULT_MSG PY2_${module_upper})
+  set (PY2_${module}_FOUND ${PY2_${module}_FOUND} PARENT_SCOPE)
+  set (PY2_${module_upper}_FOUND ${PY2_${module_upper}_FOUND} PARENT_SCOPE)
+
+endfunction(esma_find_python2_module)
+
+

--- a/esma_find_python3_module.cmake
+++ b/esma_find_python3_module.cmake
@@ -1,0 +1,32 @@
+#
+# Usage:  esma_find_python3_module(<module> [REQUIRED])
+#
+
+# Citation: https://cmake.org/pipermail/cmake/2011-January/041666.html
+# Mark Moll
+
+function(esma_find_python3_module module)
+  string(TOUPPER ${module} module_upper)
+  if(NOT PY3_${module_upper})
+    if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
+      set(PY3_${module}_FIND_REQUIRED TRUE)
+    endif()
+    # A module's location is usually a directory, but for binary modules
+    # it's a .so file.
+    execute_process(COMMAND "${Python3_EXECUTABLE}" "-c" 
+      "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+      RESULT_VARIABLE _${module}_status 
+      OUTPUT_VARIABLE _${module}_location
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _${module}_status)
+      set(PY3_${module_upper} ${_${module}_location} CACHE STRING 
+	"Location of Python3 module ${module}")
+    endif(NOT _${module}_status)
+  endif(NOT PY3_${module_upper})
+  find_package_handle_standard_args(PY3_${module} DEFAULT_MSG PY3_${module_upper})
+  set (PY3_${module}_FOUND ${PY3_${module}_FOUND} PARENT_SCOPE)
+  set (PY3_${module_upper}_FOUND ${PY3_${module_upper}_FOUND} PARENT_SCOPE)
+
+endfunction(esma_find_python3_module)
+
+


### PR DESCRIPTION
This PR essentially adds Python2 and Python3 versions of all the f2py and other Python bits in ESMA_cmake. 

Note that this will require changes for anything that uses the macros. For example, before with, say, GFIO we had:
```cmake
if (F2PY_FOUND)
   if (precision STREQUAL "r4")
   add_f2py_module(GFIO_ SOURCES GFIO_py.F90
      DESTINATION lib/Python
      ONLY gfioopen gfiocreate gfiodiminquire gfioinquire
      gfiogetvar gfiogetvart gfioputvar gfiogetbegdatetime
      gfiointerpxy gfiointerpnn gfiocoordnn gfioclose
      )
   add_dependencies(GFIO_ ${this})
   endif ()
endif ()
```
Now one would do:
```cmake
if (USE_F2PY)
   if (precision STREQUAL "r4")
   find_package(F2PY2)
      if (F2PY2_FOUND)
         esma_add_f2py2_module(GFIO_ SOURCES GFIO_py.F90
            DESTINATION lib/Python2
            ONLY gfioopen gfiocreate gfiodiminquire gfioinquire
            gfiogetvar gfiogetvart gfioputvar gfiogetbegdatetime
            gfiointerpxy gfiointerpnn gfiocoordnn gfioclose
            )
         add_dependencies(GFIO_ ${this})
      endif ()
   endif()
endif ()
```
This moves the `USE_F2PY` up to each call for f2py as well as the need for a `find_package` call as well.

Also note that in the PR, `esma_add_f2pyX_module()` was updated so that it will actually run `python -c 'import module'` after building the module. This will only work for "simple" f2py modules that don't need other bits of GEOS (aka MAPL)