### PR TITLE
Merge Develop into Main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-- Added option to BUILD_WITH_PFLOGGER
+## [3.3.9] - 2021-04-14
+
+### Added
+
+- Added option `BUILD_WITH_PFLOGGER` which defaults to `ON`. This is
+  added for collaborators that do not use pFlogger
 
 ## [3.3.8] - 2021-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+- Added option to BUILD_WITH_PFLOGGER
+
 ## [3.3.8] - 2021-04-09
 
 ### Added

--- a/FindBaselibs.cmake
+++ b/FindBaselibs.cmake
@@ -60,8 +60,11 @@ if (Baselibs_FOUND)
   find_package(GFTL_SHARED REQUIRED)
   find_package(FARGPARSE QUIET)
   find_package(YAFYAML REQUIRED)
-  find_package(PFLOGGER REQUIRED)
 
+  option(BUILD_WITH_PFLOGGER "use pFlogger" ON)
+  if (BUILD_WITH_PFLOGGER)
+    find_package(PFLOGGER REQUIRED)
+  endif()
   # Need to do a bit of kludgy stuff here to allow Fortran linker to
   # find standard C and C++ libraries used by ESMF.
   # _And_ ESMF uses libc++ on some configs and libstdc++ on others.


### PR DESCRIPTION
This pulls `develop` into `main` for a release. Added the `BUILD_WITH_PFLOGGER` option.