### PR TITLE
Improved fix for #175 - custom FPP defs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Previous option `CPP_DEBUG_<target` has now been replaced with a
+  more fine-grained combination of cmake variables: `XFLAGS` and
+  `XFLAGS_SOURCES`.   To use
+  
+  ```
+  $cmake .. -DXFLAGS="foo bar=7 DEBUG" -DXFLAGS_SOURCES="<file1> <file2>"
+  $ make
+  ```
+  
+  NOTE: This change requires checking for specified sources in every
+  directory (or rather in those that use `esma_set_this()` and thus
+  add some overhead to cmake.  We may later decide to implement a
+  per-target or per-directory pair of flags to address this, but that
+  will be harder for the user to use.
+  
+  
+
 ### Fixed
 ### Removed
 ### Added

--- a/esma.cmake
+++ b/esma.cmake
@@ -127,6 +127,9 @@ option (ESMA_ALLOW_DEPRECATED "suppress warnings about deprecated features" ON)
 # Temporary option for transition purposes.
 option (ESMA_USE_GFE_NAMESPACE "use cmake namespace with GFE projects" OFF)
 
+set (XFLAGS "" CACHE STRING "List of extra FPP options that will be passed to select source files.")
+set (XFLAGS_SOURCES "" CACHE STRING "List of sources to which XFLAGS will be applied.")
+
 # Baselibs ...
 include (FindBaselibs)
 

--- a/esma_add_library.cmake
+++ b/esma_add_library.cmake
@@ -98,13 +98,6 @@ macro (esma_add_library this)
     ${NOINSTALL_}
     )
 
-  set (CPP_DEBUG_${this} "" CACHE STRING "List of files to pass -DDEBUG")
-  foreach (file ${CPP_DEBUG_${this}})
-    ecbuild_info("setting debug option for ${file}")
-    set_source_files_properties (${file} PROPERTIES COMPILE_DEFINITIONS -DDEBUG)
-  endforeach()
-
-
   set_target_properties(${this} PROPERTIES EXCLUDE_FROM_ALL ${ARGS_EXCLUDE_FROM_ALL})
   set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${esma_include}/${this})
 

--- a/esma_set_this.cmake
+++ b/esma_set_this.cmake
@@ -37,8 +37,18 @@ macro (esma_set_this)
   file (MAKE_DIRECTORY ${esma_etc}/${this})
 
   # Control debugging for this subtree
-
   esma_check_if_debug()
+
+  # Control extra flags in this dir
+  if (XFLAGS_SOURCES)
+    string (REPLACE " " ";" local_sources ${XFLAGS_SOURCES})
+    if (XFLAGS)
+      string (REPLACE " " ";" extra_flags ${XFLAGS})
+      foreach (file ${local_sources})
+	set_property (SOURCE ${file} APPEND PROPERTY COMPILE_DEFINITIONS "${extra_flags}")
+      endforeach()
+    endif ()
+  endif ()
 
 endmacro()
 


### PR DESCRIPTION
This change allows users to specify specific extra FPP definitions to
a select group of source files.  To use:

  ```
  $cmake .. -DXFLAGS="foo bar=7 DEBUG" -DXFLAGS_SOURCES="<file1> <file2>"
  $ make
  ```