### PR TITLE
Add ability to detect BASEDIR from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+### Fixed
+### Removed
+### Added
+
 ## [3.4.3] - 2021-Jun-04
 
 ### Changed
@@ -27,10 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   add some overhead to cmake.  We may later decide to implement a
   per-target or per-directory pair of flags to address this, but that
   will be harder for the user to use.
-
-### Fixed
-### Removed
-### Added
 
 ## [3.4.2] - 2021-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add ability to detect BASEDIR from the environment.
 - Add checks to `FindBaselibs.cmake` to make sure BASEDIR has the right arch (as defined by `uname -s`) as this is still a requirement for
-  GEOS run scripts. The code will also try to make a valid BASEDIR. That is, if you pass in /path/to/baselibs, but it sees a
-  /path/to/baselibs/arch/lib exists, it will allow that.
+  GEOS run scripts. The code will also try to make a valid BASEDIR. That is, if you pass in `/path/to/baselibs`, but it sees a
+  `/path/to/baselibs/arch/lib` exists, it will allow that and try to use it.
 
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Add ability to detect BASEDIR from the environment.
+- Add checks to `FindBaselibs.cmake` to make sure BASEDIR has the right arch (as defined by `uname -s`) as this is still a requirement for
+  GEOS run scripts. The code will also try to make a valid BASEDIR. That is, if you pass in /path/to/baselibs, but it sees a
+  /path/to/baselibs/arch/lib exists, it will allow that.
+
 ### Fixed
 ### Removed
 ### Added

--- a/FindBaselibs.cmake
+++ b/FindBaselibs.cmake
@@ -1,10 +1,67 @@
-set (BASEDIR "" CACHE PATH "Path to installed baselibs _including_ OS subdirectory (Linux or Darwin).")
+set (BASEDIR "" CACHE PATH "Path to installed baselibs")
 set (Baselibs_FOUND FALSE)
 
+# We want to detect if BASEDIR is set in the environment (but not on the command line)
+if (NOT BASEDIR AND DEFINED ENV{BASEDIR})
+  message (STATUS "BASEDIR not set on command line, but found BASEDIR in the environment")
+  set (BASEDIR $ENV{BASEDIR})
+  set (BASEDIR_FROM_ENVIRONMENT TRUE)
+else ()
+  set (BASEDIR_FROM_ENVIRONMENT FALSE)
+endif ()
+
+# Next, GEOS requires all BASEDIR to be of the format
+# BASEDIR/ARCH/lib, say, where ARCH is the output of `uname -s`
+# In CMake this is CMAKE_HOST_SYSTEM_NAME
+
 if (BASEDIR)
+  # First, what if we have a BASEDIR/lib, let's make sure it's like we want
+  # That is, it has ARCH and it's the *right* ARCH!
   if (IS_DIRECTORY ${BASEDIR}/lib)
+
+    # Get the last directory node in BASEDIR
+    get_filename_component(SHOULD_BE_ARCH ${BASEDIR} NAME)
+
+    # Test to make sure it's the right arch
+    if (NOT SHOULD_BE_ARCH STREQUAL ${CMAKE_HOST_SYSTEM_NAME})
+      message(FATAL_ERROR
+        "GEOS requires that BASEDIR be such that /path/to/baselibs/${CMAKE_HOST_SYSTEM_NAME}/lib exists\n"
+        "However, you provided\n"
+        "   ${BASEDIR} \n"
+        "which does not have the correct format. Please make sure BASEDIR is correctly built and set."
+        )
+    endif ()
+
     set (Baselibs_FOUND TRUE)
     message (STATUS "BASEDIR: ${BASEDIR}")
+  # what if BASEDIR doesn't have ARCH, so we look for BASEDIR/ARCH/lib
+  elseif (IS_DIRECTORY ${BASEDIR}/${CMAKE_HOST_SYSTEM_NAME}/lib)
+    # Then we re-set BASEDIR so that it has the ARCH as that's what the CMake
+    # system here expects
+    message (STATUS "BASEDIR passed in without ${CMAKE_HOST_SYSTEM_NAME}. Setting BASEDIR internally to ${BASEDIR}/${CMAKE_HOST_SYSTEM_NAME}.")
+    set (BASEDIR ${BASEDIR}/${CMAKE_HOST_SYSTEM_NAME})
+    # Say we found Baselibs
+    set (Baselibs_FOUND TRUE)
+    # And output a message
+    message (STATUS "BASEDIR: ${BASEDIR}")
+
+  # If we get here, we have a BASEDIR, but it's not right...
+  else ()
+    if (NOT BASEDIR_FROM_ENVIRONMENT)
+      message(FATAL_ERROR
+        "GEOS requires that BASEDIR be such that /path/to/baselibs/${CMAKE_HOST_SYSTEM_NAME}/lib exists\n"
+        "However, you provided\n"
+        "   ${BASEDIR} \n"
+        "but a good path not seem to exist. Please check your input"
+        )
+    else ()
+      message(FATAL_ERROR
+        "GEOS requires that BASEDIR be such that /path/to/baselibs/${CMAKE_HOST_SYSTEM_NAME}/lib exists\n"
+        "However, we found\n"
+        "   ${BASEDIR} \n"
+        "in the environment, but a good path does not seem to exist. Please check your input"
+        )
+    endif ()
   endif ()
 else ()
   message (STATUS "WARNING: BASEDIR not specified. Please use cmake ... -DBASEDIR=<path>.")

--- a/FindBaselibs.cmake
+++ b/FindBaselibs.cmake
@@ -47,21 +47,15 @@ if (BASEDIR)
 
   # If we get here, we have a BASEDIR, but it's not right...
   else ()
-    if (NOT BASEDIR_FROM_ENVIRONMENT)
-      message(FATAL_ERROR
-        "GEOS requires that BASEDIR be such that /path/to/baselibs/${CMAKE_HOST_SYSTEM_NAME}/lib exists\n"
-        "However, you provided\n"
-        "   ${BASEDIR} \n"
-        "but a good path not seem to exist. Please check your input"
-        )
-    else ()
-      message(FATAL_ERROR
-        "GEOS requires that BASEDIR be such that /path/to/baselibs/${CMAKE_HOST_SYSTEM_NAME}/lib exists\n"
-        "However, we found\n"
-        "   ${BASEDIR} \n"
-        "in the environment, but a good path does not seem to exist. Please check your input"
-        )
+    if (BASEDIR_FROM_ENVIRONMENT)
+      set (EXTRA_TEXT "in the environment, ")
     endif ()
+    message(FATAL_ERROR
+      "GEOS requires that BASEDIR be such that /path/to/baselibs/${CMAKE_HOST_SYSTEM_NAME}/lib exists\n"
+      "However, we found\n"
+      "   ${BASEDIR} \n"
+      "${EXTRA_TEXT}but a good path does not seem to exist. Please check your input"
+      )
   endif ()
 else ()
   message (STATUS "WARNING: BASEDIR not specified. Please use cmake ... -DBASEDIR=<path>.")

--- a/FindBaselibs.cmake
+++ b/FindBaselibs.cmake
@@ -1,5 +1,5 @@
 set (BASEDIR "" CACHE PATH "Path to installed baselibs")
-set (Baselibs_FOUND FALSE)
+set (Baselibs_FOUND FALSE CACHE BOOL "Baselibs Found")
 
 # We want to detect if BASEDIR is set in the environment (but not on the command line)
 if (NOT BASEDIR AND DEFINED ENV{BASEDIR})
@@ -32,7 +32,7 @@ if (BASEDIR)
         )
     endif ()
 
-    set (Baselibs_FOUND TRUE)
+    set (Baselibs_FOUND TRUE CACHE BOOL "Baselibs Found" FORCE)
     message (STATUS "BASEDIR: ${BASEDIR}")
   # what if BASEDIR doesn't have ARCH, so we look for BASEDIR/ARCH/lib
   elseif (IS_DIRECTORY ${BASEDIR}/${CMAKE_HOST_SYSTEM_NAME}/lib)
@@ -41,7 +41,7 @@ if (BASEDIR)
     message (STATUS "BASEDIR passed in without ${CMAKE_HOST_SYSTEM_NAME}. Setting BASEDIR internally to ${BASEDIR}/${CMAKE_HOST_SYSTEM_NAME}.")
     set (BASEDIR ${BASEDIR}/${CMAKE_HOST_SYSTEM_NAME})
     # Say we found Baselibs
-    set (Baselibs_FOUND TRUE)
+    set (Baselibs_FOUND TRUE CACHE BOOL "Baselibs Found" FORCE)
     # And output a message
     message (STATUS "BASEDIR: ${BASEDIR}")
 


### PR DESCRIPTION
This PR does a couple things:
- Add ability to detect BASEDIR from the environment.
- Add checks to `FindBaselibs.cmake` to make sure BASEDIR has the right arch (as defined by `uname -s`) as this is still a requirement for GEOS run scripts. The code will also try to make a valid BASEDIR. That is, if you pass in `/path/to/baselibs`, but it sees a `/path/to/baselibs/arch/lib` exists, it will allow that and try to use it.
