### PR TITLE
Use ESMF dylib on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-
-- Change `ESMA_USE_GFE_NAMESPACE` default to `ON`. This requires Baselibs v6.2 or the latest libraries
-- On Linux, link to `libesmf.so` rather than `libesmf_fullylinked.so`
-  per advice of ESMF developers.
-
 ### Fixed
 ### Removed
 ### Added
+
+## [3.5.0] - 2021-Jun-08
+
+### Changed
+
+- Change `ESMA_USE_GFE_NAMESPACE` default to `ON`. This requires Baselibs v6.2 or the latest libraries
+- On Linux, link to `libesmf.so` rather than `libesmf_fullylinked.so` per advice of ESMF developers.
+- On macOS, link to `libesmf.dylib` rather than `libesmf.a`. This requires Baselibs v6.2.5 as that has a bug fix for ESMF dylib handling
 
 ## [3.4.3] - 2021-Jun-04
 

--- a/FindBaselibs.cmake
+++ b/FindBaselibs.cmake
@@ -138,16 +138,21 @@ if (Baselibs_FOUND)
     execute_process (COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libstdc++.so OUTPUT_VARIABLE stdcxx OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif ()
 
-  # We must statically link ESMF on Apple due mainly to an issue with how Baselibs is built.
-  # Namely, the esmf dylib libraries end up with the full *build* path on Darwin (which is in
-  # src/esmf/lib/libO...) But we copy the dylib to $BASEDIR/lib. Thus, DYLD_LIBRARY_PATH gets
-  # hosed. yay.
+  # With Baselibs 6.2.5, we can now link to the ESMF dynamic library on macOS
+  set (ESMF_LIBRARY esmf)
+  # Now set the suffix. Note that unfortunately CMAKE_SHARED_MODULE_SUFFIX doesn't
+  # quite do what we want (sets .so on macOS here), so we say "dylib" or "so"
   if (APPLE)
-     set (ESMF_LIBRARY ${BASEDIR}/lib/libesmf.a)
-     set (ESMF_LIBRARY_PATH ${ESMF_LIBRARY})
+    set (ESMF_LIBRARY_SUFFIX "dylib")
   else ()
-     set (ESMF_LIBRARY esmf)
-     set (ESMF_LIBRARY_PATH ${BASEDIR}/lib/lib${ESMF_LIBRARY}.so)
+    set (ESMF_LIBRARY_SUFFIX "so")
+  endif ()
+  set (ESMF_LIBRARY_PATH ${BASEDIR}/lib/lib${ESMF_LIBRARY}.${ESMF_LIBRARY_SUFFIX})
+
+  if (NOT EXISTS ${ESMF_LIBRARY_PATH})
+    message (FATAL_ERROR "Cannot find ${ESMF_LIBRARY_PATH}")
+  else ()
+    message(STATUS "ESMF_LIBRARY_PATH: ${ESMF_LIBRARY_PATH}")
   endif ()
 
   set (NETCDF_LIBRARIES ${NETCDF_LIBRARIES_OLD})


### PR DESCRIPTION
This PR updates ESMA_cmake to use `libesmf.dylib` on macOS. This is now possible with [Baselibs v6.2.5](https://github.com/GEOS-ESM/ESMA-Baselibs/releases/tag/v6.2.5). Linux is not affected by this PR. 

I also added a little check so that it makes sure `libesmf.so` or `libesmf.dylib` exists.