### PR TITLE
Update minimum Fortran versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Update minimum Fortran compiler versions
+  - Intel 18.0.5
+  - GNU 9.2.0
+  - NAG 7.0
+
 ### Fixed
 ### Removed
 ### Added

--- a/GNU.cmake
+++ b/GNU.cmake
@@ -1,5 +1,5 @@
-if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 8.3)
-  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 8.3!")
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 9.3)
+  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 9.4!")
 endif()
 
 set (FOPT0 "-O0")

--- a/GNU.cmake
+++ b/GNU.cmake
@@ -1,5 +1,5 @@
-if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 9.3)
-  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 9.4!")
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 9.2)
+  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 9.2!")
 endif()
 
 set (FOPT0 "-O0")

--- a/Intel.cmake
+++ b/Intel.cmake
@@ -1,6 +1,8 @@
-if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 15.1)
-  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 15.1!")
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 18.0.5)
+  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 18.0.5!")
 endif()
+
+message(STATUS "MATMAT CMAKE_Fortran_COMPILER_VERSION: ${CMAKE_Fortran_COMPILER_VERSION}")
 
 set (FOPT0 "-O0")
 set (FOPT1 "-O1")

--- a/NAG.cmake
+++ b/NAG.cmake
@@ -1,5 +1,5 @@
-if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 6.0)
-  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 6.0!")
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 7.0)
+  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 7.0!")
 endif()
 
 set (FREAL8 "-r8")


### PR DESCRIPTION
Given recent events in MAPL and GOCART, I'm proposing increasing the minimum compilers supported by ESMA_cmake to:

* Intel 18.0.5
* GNU 9.2.0
* NAG 7.0