### PR TITLE
Make f2py noisier if building Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.5.3] - 2021-Aug-03
+
+### Changed
+
+- If building `CMAKE_BUILD_TYPE=Debug` the f2py steps are now more verbose to aid in debugging
+
+
 ## [3.5.2] - 2021-Jul-14
 
 ### Fixed
@@ -31,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `ESMA_USE_GFE_NAMESPACE` default to `ON`. This requires Baselibs v6.2 or the latest libraries
 - On Linux, link to `libesmf.so` rather than `libesmf_fullylinked.so` per advice of ESMF developers.
 - On macOS, link to `libesmf.dylib` rather than `libesmf.a`. This requires Baselibs v6.2.5 as that has a bug fix for ESMF dylib handling
+
+## [3.4.5] - 2021-Aug-03
+
+### Changed
+
+- If building `CMAKE_BUILD_TYPE=Debug` the f2py steps are now more verbose to aid in debugging
+
+## [3.4.4] - 2021-Jul-14
+
+### Fixed
+
+- Changes to `esma_add_f2pyX_module` macros in handling the `python -c 'import foo_'` tests. Adds `LD_LIBRARY_PATH` to it. Still does not fix all problems.
 
 ## [3.4.3] - 2021-Jun-04
 

--- a/UseF2Py.cmake
+++ b/UseF2Py.cmake
@@ -190,24 +190,35 @@ macro (add_f2py_module _name)
      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/.f2py_f2cmap "{'real':{'':'double'},'integer':{'':'long'},'real*8':{'':'double'},'complex':{'':'complex_double'}}")
   endif()
 
+  # Debugging f2py is a lot easier if you don't quiet it, but we do not
+  # want all the f2py output when building normally as it is *very*
+  # verbose. So this turns out the f2py verboseness when building for Debug
+  if (NOT CMAKE_BUILD_TYPE MATCHES Debug)
+    set (F2PY_QUIET "--quiet")
+    # Note: Need to use a "list" like this because of CMake. If it
+    #       was a single string, CMake would add a backslash between
+    #       them: "&>\ /dev/null"
+    set (REDIRECT_TO_DEV_NULL "&>" "/dev/null")
+  endif ()
+
   # Define the command to generate the Fortran to Python interface module. The
   # output will be a shared library that can be imported by python.
   if ( "${add_f2py_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
     add_custom_command(OUTPUT "${_name}${F2PY_SUFFIX}"
-      COMMAND ${F2PY_EXECUTABLE} --quiet -m ${_name}
+      COMMAND ${F2PY_EXECUTABLE} ${F2PY_QUIET} -m ${_name}
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py-${_name}"
-              ${_fcompiler_opts} ${_inc_opts} -c ${_abs_srcs} &> /dev/null
+              ${_fcompiler_opts} ${_inc_opts} -c ${_abs_srcs} ${REDIRECT_TO_DEV_NULL}
       DEPENDS ${add_f2py_module_SOURCES}
       COMMENT "[F2PY] Building Fortran to Python interface module ${_name}")
   else ( "${add_f2py_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
     add_custom_command(OUTPUT "${_name}${F2PY_SUFFIX}"
-      COMMAND ${F2PY_EXECUTABLE} --quiet -m ${_name} -h ${_name}.pyf
+      COMMAND ${F2PY_EXECUTABLE} ${F2PY_QUIET} -m ${_name} -h ${_name}.pyf
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py-${_name}"
-              --include-paths ${_inc_paths} --overwrite-signature ${_abs_srcs} &> /dev/null
-      COMMAND ${F2PY_EXECUTABLE} --quiet -m ${_name}
+              --include-paths ${_inc_paths} --overwrite-signature ${_abs_srcs} ${REDIRECT_TO_DEV_NULL}
+      COMMAND ${F2PY_EXECUTABLE} ${F2PY_QUIET} -m ${_name}
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py-${_name}"
               -c "${CMAKE_CURRENT_BINARY_DIR}/f2py-${_name}/${_name}.pyf"
-              ${_fcompiler_opts} ${_inc_opts} ${_lib_opts} ${_abs_srcs} ${_lib_opts} ${_only} &> /dev/null
+              ${_fcompiler_opts} ${_inc_opts} ${_lib_opts} ${_abs_srcs} ${_lib_opts} ${_only} ${REDIRECT_TO_DEV_NULL}
       DEPENDS ${add_f2py_module_SOURCES}
       COMMENT "[F2PY] Building Fortran to Python interface module ${_name}")
   endif ( "${add_f2py_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )

--- a/UseF2Py2.cmake
+++ b/UseF2Py2.cmake
@@ -190,24 +190,35 @@ macro (add_f2py2_module _name)
      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/.f2py2_f2cmap "{'real':{'':'double'},'integer':{'':'long'},'real*8':{'':'double'},'complex':{'':'complex_double'}}")
   endif()
 
+  # Debugging f2py is a lot easier if you don't quiet it, but we do not
+  # want all the f2py output when building normally as it is *very*
+  # verbose. So this turns out the f2py verboseness when building for Debug
+  if (NOT CMAKE_BUILD_TYPE MATCHES Debug)
+    set (F2PY_QUIET "--quiet")
+    # Note: Need to use a "list" like this because of CMake. If it
+    #       was a single string, CMake would add a backslash between
+    #       them: "&>\ /dev/null"
+    set (REDIRECT_TO_DEV_NULL "&>" "/dev/null")
+  endif ()
+
   # Define the command to generate the Fortran to Python2 interface module. The
   # output will be a shared library that can be imported by python.
   if ( "${add_f2py2_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
     add_custom_command(OUTPUT "${_name}${F2PY2_SUFFIX}"
-      COMMAND ${F2PY2_EXECUTABLE} --quiet -m ${_name}
+      COMMAND ${F2PY2_EXECUTABLE} ${F2PY_QUIET} -m ${_name}
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py2-${_name}"
-              ${_fcompiler_opts} ${_inc_opts} -c ${_abs_srcs} &> /dev/null
+              ${_fcompiler_opts} ${_inc_opts} -c ${_abs_srcs} ${REDIRECT_TO_DEV_NULL}
       DEPENDS ${add_f2py2_module_SOURCES}
       COMMENT "[F2PY2] Building Fortran to Python2 interface module ${_name}")
   else ( "${add_f2py2_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
     add_custom_command(OUTPUT "${_name}${F2PY2_SUFFIX}"
-      COMMAND ${F2PY2_EXECUTABLE} --quiet -m ${_name} -h ${_name}.pyf
+      COMMAND ${F2PY2_EXECUTABLE} ${F2PY_QUIET} -m ${_name} -h ${_name}.pyf
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py2-${_name}"
-              --include-paths ${_inc_paths} --overwrite-signature ${_abs_srcs} &> /dev/null
-      COMMAND ${F2PY2_EXECUTABLE} --quiet -m ${_name}
+              --include-paths ${_inc_paths} --overwrite-signature ${_abs_srcs} ${REDIRECT_TO_DEV_NULL}
+      COMMAND ${F2PY2_EXECUTABLE} ${F2PY_QUIET} -m ${_name}
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py2-${_name}"
               -c "${CMAKE_CURRENT_BINARY_DIR}/f2py2-${_name}/${_name}.pyf"
-              ${_fcompiler_opts} ${_inc_opts} ${_lib_opts} ${_abs_srcs} ${_lib_opts} ${_only} &> /dev/null
+              ${_fcompiler_opts} ${_inc_opts} ${_lib_opts} ${_abs_srcs} ${_lib_opts} ${_only} ${REDIRECT_TO_DEV_NULL}
       DEPENDS ${add_f2py2_module_SOURCES}
       COMMENT "[F2PY2] Building Fortran to Python2 interface module ${_name}")
   endif ( "${add_f2py2_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )

--- a/UseF2Py3.cmake
+++ b/UseF2Py3.cmake
@@ -190,24 +190,35 @@ macro (add_f2py3_module _name)
      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/.f2py3_f2cmap "{'real':{'':'double'},'integer':{'':'long'},'real*8':{'':'double'},'complex':{'':'complex_double'}}")
   endif()
 
+  # Debugging f2py is a lot easier if you don't quiet it, but we do not
+  # want all the f2py output when building normally as it is *very*
+  # verbose. So this turns out the f2py verboseness when building for Debug
+  if (NOT CMAKE_BUILD_TYPE MATCHES Debug)
+    set (F2PY_QUIET "--quiet")
+    # Note: Need to use a "list" like this because of CMake. If it
+    #       was a single string, CMake would add a backslash between
+    #       them: "&>\ /dev/null"
+    set (REDIRECT_TO_DEV_NULL "&>" "/dev/null")
+  endif ()
+
   # Define the command to generate the Fortran to Python3 interface module. The
   # output will be a shared library that can be imported by python.
   if ( "${add_f2py3_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
     add_custom_command(OUTPUT "${_name}${F2PY3_SUFFIX}"
-      COMMAND ${F2PY3_EXECUTABLE} --quiet -m ${_name}
+      COMMAND ${F2PY3_EXECUTABLE} ${F2PY_QUIET} -m ${_name}
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py3-${_name}"
-              ${_fcompiler_opts} ${_inc_opts} -c ${_abs_srcs} &> /dev/null
+              ${_fcompiler_opts} ${_inc_opts} -c ${_abs_srcs} ${REDIRECT_TO_DEV_NULL}
       DEPENDS ${add_f2py3_module_SOURCES}
       COMMENT "[F2PY3] Building Fortran to Python3 interface module ${_name}")
   else ( "${add_f2py3_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )
     add_custom_command(OUTPUT "${_name}${F2PY3_SUFFIX}"
-      COMMAND ${F2PY3_EXECUTABLE} --quiet -m ${_name} -h ${_name}.pyf
+      COMMAND ${F2PY3_EXECUTABLE} ${F2PY_QUIET} -m ${_name} -h ${_name}.pyf
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py3-${_name}"
-              --include-paths ${_inc_paths} --overwrite-signature ${_abs_srcs} &> /dev/null
-      COMMAND ${F2PY3_EXECUTABLE} --quiet -m ${_name}
+              --include-paths ${_inc_paths} --overwrite-signature ${_abs_srcs} ${REDIRECT_TO_DEV_NULL}
+      COMMAND ${F2PY3_EXECUTABLE} ${F2PY_QUIET} -m ${_name}
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py3-${_name}"
               -c "${CMAKE_CURRENT_BINARY_DIR}/f2py3-${_name}/${_name}.pyf"
-              ${_fcompiler_opts} ${_inc_opts} ${_lib_opts} ${_abs_srcs} ${_lib_opts} ${_only} &> /dev/null
+              ${_fcompiler_opts} ${_inc_opts} ${_lib_opts} ${_abs_srcs} ${_lib_opts} ${_only} ${REDIRECT_TO_DEV_NULL}
       DEPENDS ${add_f2py3_module_SOURCES}
       COMMENT "[F2PY3] Building Fortran to Python3 interface module ${_name}")
   endif ( "${add_f2py3_module_SOURCES}" MATCHES "^[^;]*\\.pyf;" )


### PR DESCRIPTION
In working with @patricia-nasa and others doing a lot of `f2py` work, they often need to remove the `&> /dev/null` from the macros to let them see *why* f2py is failing.

So with this PR, if you build with `Debug` `CMAKE_BUILD_TYPE` then we make `f2py` noisy again. But we only do this if you are doing `Debug` as f2py is very noisy even when things are working!

Making draft for now so I can test on discover with a GEOS build. I'll then rope in @tclune to approve.