### PR TITLE
Add esma_cpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+- Added `esma_cpack.cmake` to allow for creating tarballs of code with `make package_source` or `make dist`
+
 ## [3.5.3] - 2021-Aug-03
 
 ### Changed

--- a/esma_cpack.cmake
+++ b/esma_cpack.cmake
@@ -1,0 +1,27 @@
+# This suppresses the warning that ecbuild also does
+# an include(CPack)
+set(CPack_CMake_INCLUDED 0)
+
+set(CPACK_GENERATOR NONE)
+
+# This undo some things that ecbuild_install_project does internally
+set(CPACK_SOURCE_INSTALLED_DIRECTORIES )
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_VERBATIM_VARIABLES TRUE)
+set(CPACK_SOURCE_IGNORE_FILES
+  /.git/
+  /.mepo/
+  /build.*/
+  /install.*/
+)
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}")
+# Note we need to call this again to "overwrite" the CPack done in ecbuild
+include(CPack)
+
+# Add the familiar dist target as an alias for package_source
+add_custom_target(dist
+  COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target package_source
+  VERBATIM
+  USES_TERMINAL
+  )
+


### PR DESCRIPTION
This adds some CPack configuration to ESMA_cmake that allows one to run `make package_source` or `make dist` in a build directory and the code will be tarred up for the user.

Note that due to ecbuild oddities, the `include(esma_cpack)` needs to be done *after* the call to `ecbuild_install_project` so that our CPack wins over ecbuild's. Thus we can't just have this include in the `esma.cmake` file. Dang.