### PR TITLE
Clean up MAPL references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Updated some MAPL references in the stub and ACG code
+
 ### Fixed
 ### Removed
 ### Added

--- a/esma_create_stub_component.cmake
+++ b/esma_create_stub_component.cmake
@@ -3,7 +3,7 @@ macro (esma_create_stub_component srcs module)
 
   find_file (stub_generator
     NAME mapl_stub.pl
-    PATHS ${MAPL_SOURCE_DIR}/MAPL_Base ${esma_etc}/MAPL)
+    PATHS ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL)
 
   add_custom_command (
     OUTPUT ${module}.F90

--- a/esma_generate_automatic_code.cmake
+++ b/esma_generate_automatic_code.cmake
@@ -7,7 +7,7 @@ macro (new_esma_generate_automatic_code
 
   find_file (generator
     NAME mapl_acg.pl
-    PATHS ${esma_include}/MAPL_Base ${esma_etc}/MAPL)
+    PATHS ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL)
 
   add_custom_command (
     OUTPUT ${rcs}
@@ -59,7 +59,7 @@ macro (esma_generate_gmi_code target type)
 
   find_file (generator
     NAME mapl_acg.pl
-    PATHS ${esma_include}/MAPL_Base ${esma_etc}/MAPL)
+    PATHS ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL)
 
   add_custom_command (
     #    TARGET ${this}
@@ -85,7 +85,7 @@ macro (esma_generate_automatic_code this name destination flags)
 
   find_file (generator
     NAME mapl_acg.pl
-    PATHS ${esma_include}/MAPL_Base ${esma_etc}/MAPL)
+    PATHS ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL)
 
   add_custom_command (
     OUTPUT ${name}_ExportSpec___.h ${name}_GetPointer___.h ${name}_History___.rc


### PR DESCRIPTION
This might be a "leave well enough alone" change, but when I was looking at some code with @Gvilla1000-nasa, I saw some things in ESMA_cmake that looked odd. Namely mentions of "MAPL_Base" which hasn't been around awhile. The `mapl_acg.pl` and `mapl_stub.pl` scripts now live in `@MAPL/Apps` so I've changed two scripts here to reflect that.