### PR TITLE
Add librt and libdl to the ESMF libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Added `librt` and `libdl` to the `ESMF_LIBRARIES`
+- Added `librt` and `libdl` to the `ESMF_LIBRARIES` on Linux.
 
 ## [3.5.4] - 2021-Aug-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
+
+- Added `librt` and `libdl` to the `ESMF_LIBRARIES`
+
 ### Removed
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
-
-- Added `librt` and `libdl` to the `ESMF_LIBRARIES`
-
 ### Removed
 ### Added
+
+## [3.5.5] - 2021-Sep-07
+
+### Fixed
+
+- Added `librt` and `libdl` to the `ESMF_LIBRARIES`
 
 ## [3.5.4] - 2021-Aug-25
 

--- a/FindBaselibs.cmake
+++ b/FindBaselibs.cmake
@@ -136,6 +136,8 @@ if (Baselibs_FOUND)
     endif()
   else ()
     execute_process (COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libstdc++.so OUTPUT_VARIABLE stdcxx OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process (COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=librt.so OUTPUT_VARIABLE rt OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process (COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libdl.so OUTPUT_VARIABLE dl OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif ()
 
   # With Baselibs 6.2.5, we can now link to the ESMF dynamic library on macOS
@@ -170,7 +172,7 @@ if (Baselibs_FOUND)
   # We also need to append the pthread flag at link time
   list(APPEND NETCDF_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
 
-  set (ESMF_LIBRARIES ${ESMF_LIBRARY} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_CXX_LIBRARIES} ${stdcxx} ${libgcc})
+  set (ESMF_LIBRARIES ${ESMF_LIBRARY} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_CXX_LIBRARIES} ${rt} ${stdcxx} ${dl} ${libgcc})
 
   # Create targets
   # - NetCDF Fortran


### PR DESCRIPTION
Recently, Alexander Gruber (@alexgruber, I think), encountered an issue with GEOSldas when linking to ESMF:
```
[ 61%] Linking Fortran executable ../../../../bin/cub2latlon.x
/staging/leuven/stg_00024/GEOSldas_libraries/ESMA-Baselibs-6.2.4/src/Linux/lib/libesmf.so: error: undefined reference to 'shm_open'
/staging/leuven/stg_00024/GEOSldas_libraries/ESMA-Baselibs-6.2.4/src/Linux/lib/libesmf.so: error: undefined reference to 'shm_unlink'
collect2: error: ld returned 1 exit status
make[2]: *** [bin/cub2latlon.x] Error 1
make[1]: *** [src/Shared/@MAPL/base/CMakeFiles/cub2latlon.x.dir/all] Error 2
```
This is the first time I've seen it. I *think* the fix is to add `librt` and `libdl` to the `ESMF_LIBRARIES` for GEOS. 

This PR is where I'm tracking this, depending on how it works for @alexgruber (since, well, I can't reproduce it!)