### PR TITLE
Fixes #216. Cache BASEDIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored ESMA_cmake
 
 ### Fixed
+
+- Cache BASEDIR when a valid path is found 
+
 ### Removed
 ### Added
 

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -1,4 +1,3 @@
-set (BASEDIR "" CACHE PATH "Path to installed baselibs")
 set (Baselibs_FOUND FALSE CACHE BOOL "Baselibs Found")
 
 # We want to detect if BASEDIR is set in the environment (but not on the command line)
@@ -57,6 +56,7 @@ if (BASEDIR)
       "${EXTRA_TEXT}but a good path does not seem to exist. Please check your input"
       )
   endif ()
+  set (BASEDIR "${BASEDIR}" CACHE PATH "Path to installed baselibs")
 else ()
   message (STATUS "WARNING: BASEDIR not specified. Please use cmake ... -DBASEDIR=<path>.")
 endif ()


### PR DESCRIPTION
Closes #216 

If you run CMake from a terminal that does have BASEDIR defined, but then move to a terminal that doesn't, subsequent `cmake` will fail. This PR changes the order of some statements so that when a good BASEDIR is found, it is then cached.