### PR TITLE
Fix tests target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
+
+- Fix issue with `tests` target due to bad refactor
+
 ### Removed
 ### Added
 

--- a/esma.cmake
+++ b/esma.cmake
@@ -50,14 +50,7 @@ include (esma_compiler)
 ### ESMA Support ###
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/esma_support")
-include (esma_check_if_debug)
-include (esma_set_this)
-include (esma_add_subdirectories)
-include (esma_mepo_style)
-include (esma_add_library)
-include (esma_generate_automatic_code)
-include (esma_create_stub_component)
-include (esma_fortran_generator_list)
+include (esma_support)
 
 ### Python ###
 

--- a/esma_support/esma_support.cmake
+++ b/esma_support/esma_support.cmake
@@ -3,6 +3,7 @@
 include (esma_check_if_debug)
 include (esma_set_this)
 include (esma_add_subdirectories)
+include (esma_mepo_style)
 include (esma_add_library)
 include (esma_generate_automatic_code)
 include (esma_create_stub_component)


### PR DESCRIPTION
The refactoring done in #207 had a mistake that broke `make tests` in MAPL. This fixes that issue.

Essentially, this:
```cmake
include (esma_enable_tests)
```
was never being called before.