### PR TITLE
Restore the old Intel non-vectorized Release flags as new NoVect variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Created a new set of flags for Intel that mimic the old non-vectorized Release flags
+
 ### Fixed
 ### Removed
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+### Fixed
+### Removed
+### Added
+
+## [3.6.1] - 2021-Oct-05
+
+### Changed
 
 - Created a new set of flags for Intel that mimic the old non-vectorized Release flags
 
 ### Fixed
 
 - Fix issue with `tests` target due to bad refactor
-
-### Removed
-### Added
 
 ## [3.6.0] - 2021-Oct-01
 

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -146,6 +146,13 @@ set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 set (GEOS_Fortran_Release_Flags "${FOPT3} -march=${GNU_TARGET_ARCH} -mtune=generic -funroll-loops ${DEBINFO}")
 set (GEOS_Fortran_Release_FPE_Flags "${common_Fortran_fpe_flags}")
 
+# Create a NoVectorize version for consistency. No difference from Release for GNU
+
+# GEOS NoVectorize
+# ----------------
+set (GEOS_Fortran_NoVect_Flags  "${GEOS_Fortran_Release_Flags}")
+set (GEOS_Fortran_NoVect_FPE_Flags "${GEOS_Fortran_Release_FPE_Flags}")
+
 # GEOS Vectorize
 # --------------
 # NOTE: gfortran does get a benefit from vectorization, but the resulting code

--- a/compiler/flags/Generic_Fortran.cmake
+++ b/compiler/flags/Generic_Fortran.cmake
@@ -1,6 +1,7 @@
 set (GEOS_Fortran_FLAGS_DEBUG       "${GEOS_Fortran_Debug_Flags} ${common_Fortran_flags} ${GEOS_Fortran_Debug_FPE_Flags} ${ALIGNCOM}")
 set (GEOS_Fortran_FLAGS_RELEASE     "${GEOS_Fortran_Release_Flags} ${common_Fortran_flags} ${GEOS_Fortran_Release_FPE_Flags} ${ALIGNCOM}")
 set (GEOS_Fortran_FLAGS_VECT        "${GEOS_Fortran_Vect_Flags} ${common_Fortran_flags} ${GEOS_Fortran_Vect_FPE_Flags} ${ALIGNCOM}")
+set (GEOS_Fortran_FLAGS_NOVECT      "${GEOS_Fortran_NoVect_Flags} ${common_Fortran_flags} ${GEOS_Fortran_NoVect_FPE_Flags} ${ALIGNCOM}")
 set (GEOS_Fortran_FLAGS_AGGRESSIVE  "${GEOS_Fortran_Aggressive_Flags} ${common_Fortran_flags} ${GEOS_Fortran_Aggressive_FPE_Flags} ${ALIGNCOM}")
 
 set (CMAKE_Fortran_FLAGS_DEBUG      "${GEOS_Fortran_FLAGS_DEBUG}"      CACHE STRING "Debug Fortran flags"      FORCE )

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -70,20 +70,21 @@ set (common_Fortran_fpe_flags "${FPE0} ${FP_MODEL_SOURCE} ${HEAPARRAYS} ${NOOLD_
 set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check all,noarg_temp_created -fp-stack-check -warn unused -init=snan,arrays -save-temps")
 set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 
-# GEOS Release
-# ------------
+# GEOS NoVectorize
+# ----------------
 set (GEOS_Fortran_NoVect_Flags "${FOPT3} ${DEBINFO} ${OPTREPORT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS}")
 set (GEOS_Fortran_NoVect_FPE_Flags "${common_Fortran_fpe_flags} ${ARCH_CONSISTENCY}")
 
 # NOTE It was found that the Vectorizing Flags gave better performance with the same results in testing.
-#      So we keep the old flags commented out for now for historical purposes until all of GEOS can
-#      transition to Vect is Release (there are CMakeLists.txt files through GEOS referring to Vect)
+#      But in case they are needed, we keep the older flags available
 
 # GEOS Vectorize
 # --------------
 set (GEOS_Fortran_Vect_Flags "${FOPT3} ${DEBINFO} ${COREAVX2_FLAG} -fma -qopt-report0 ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -align array32byte")
 set (GEOS_Fortran_Vect_FPE_Flags "${FPE3} ${FP_MODEL_CONSISTENT} ${NOOLD_MAXMINLOC}")
 
+# GEOS Release
+# ------------
 set (GEOS_Fortran_Release_Flags  "${GEOS_Fortran_Vect_Flags}")
 set (GEOS_Fortran_Release_FPE_Flags "${GEOS_Fortran_Vect_FPE_Flags}")
 

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -72,8 +72,8 @@ set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 
 # GEOS Release
 # ------------
-#set (GEOS_Fortran_Release_Flags "${FOPT3} ${DEBINFO} ${OPTREPORT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS}")
-#set (GEOS_Fortran_Release_FPE_Flags "${common_Fortran_fpe_flags} ${ARCH_CONSISTENCY}")
+set (GEOS_Fortran_NoVect_Flags "${FOPT3} ${DEBINFO} ${OPTREPORT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS}")
+set (GEOS_Fortran_NoVect_FPE_Flags "${common_Fortran_fpe_flags} ${ARCH_CONSISTENCY}")
 
 # NOTE It was found that the Vectorizing Flags gave better performance with the same results in testing.
 #      So we keep the old flags commented out for now for historical purposes until all of GEOS can

--- a/compiler/flags/NAG_Fortran.cmake
+++ b/compiler/flags/NAG_Fortran.cmake
@@ -29,6 +29,13 @@ set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 set (GEOS_Fortran_Release_Flags "-O3 -g")
 set (GEOS_Fortran_Release_FPE_Flags "${common_Fortran_fpe_flags}")
 
+# Create a NoVectorize version for consistency. No difference from Release for NAG
+
+# GEOS NoVectorize
+# ----------------
+set (GEOS_Fortran_NoVect_Flags  "${GEOS_Fortran_Release_Flags}")
+set (GEOS_Fortran_NoVect_FPE_Flags "${GEOS_Fortran_Release_FPE_Flags}")
+
 # GEOS Vectorize
 # --------------
 # Until good options can be found, make vectorize equal common flags

--- a/compiler/flags/PGI_Fortran.cmake
+++ b/compiler/flags/PGI_Fortran.cmake
@@ -40,6 +40,13 @@ set (GEOS_Fortran_Release_FPE_Flags "${common_Fortran_fpe_flags}")
 
 # NOTE: No idea how to handle GPU with CMake
 
+# Create a NoVectorize version for consistency. No difference from Release for PGI
+
+# GEOS NoVectorize
+# ----------------
+set (GEOS_Fortran_NoVect_Flags  "${GEOS_Fortran_Release_Flags}")
+set (GEOS_Fortran_NoVect_FPE_Flags "${GEOS_Fortran_Release_FPE_Flags}")
+
 # GEOS Vectorize
 # --------------
 # Until good options can be found, make vectorize equal common flags


### PR DESCRIPTION
It turns out CICE4 cannot run with the new all-vectorized flags (see https://github.com/GEOS-ESM/GEOSgcm/issues/336). In order to use the old flags, this creates a new set of "NoVect" variables that are the old `Release` flags.