### PR TITLE
Fix bug in BASEDIR caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.6.3] - 2021-Oct-14
+
+### Fixed
+
+- Fixed bug in caching `BASEDIR`
+
 ## [3.6.2] - 2021-Oct-06
 
 ### Changed

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -56,7 +56,7 @@ if (BASEDIR)
       "${EXTRA_TEXT}but a good path does not seem to exist. Please check your input"
       )
   endif ()
-  set (BASEDIR "${BASEDIR}" CACHE PATH "Path to installed baselibs")
+  set (BASEDIR "${BASEDIR}" CACHE PATH "Path to installed baselibs" FORCE)
 else ()
   ecbuild_warn(
     "BASEDIR not specified.\n"


### PR DESCRIPTION
Fixes a bug in how we cache `BASEDIR`. This was seen because:
```
cmake --preset Release
```
was broken.