### PR TITLE
Changelog fix on main into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
-
-- Attempt to detect SSL library path and use that with f2py
-
 ### Removed
 ### Added
+
+## [3.6.6] - 2021-Oct-21
+
+### Fixed
+
+- Attempt to detect SSL library path and use that with f2py
 
 ## [3.6.5] - 2021-Oct-18
 


### PR DESCRIPTION
I forgot to update the changelog for the new release. So I did it on `main` and now I need to merge into `develop`