### PR TITLE
Remove find_package from FindBaselibs.cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 executors:
-  gcc-build-env:
+  gfortran:
     docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
+      - image: gmao/ubuntu20-geos-env-mkl:v6.2.8-openmpi_4.0.6-gcc_11.2.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN
@@ -11,6 +11,16 @@ executors:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMPI_MCA_btl_vader_single_copy_mechanism: none
+      MPIEXEC_PREFLAGS: --oversubscribe
+    resource_class: large
+    #MEDIUM# resource_class: medium
+
+  ifort:
+    docker:
+      - image: gmao/ubuntu20-geos-env:v6.2.8-intelmpi_2021.2.0-intel_2021.2.0
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_AUTH_TOKEN
     resource_class: large
     #MEDIUM# resource_class: medium
 
@@ -19,41 +29,141 @@ workflows:
   build-test:
     jobs:
       - build-GEOSgcm:
+          name: build-GEOSgcm-on-<< matrix.compiler >>
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
           context:
             - docker-hub-creds
 
+commands:
+  versions:
+    description: "Versions, etc."
+    parameters:
+      compiler:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: "Versions, etc."
+          command: |
+            mpirun --version && << parameters.compiler >> --version && echo $BASEDIR && pwd && ls && echo "$(nproc)"
+
+  checkout_fixture:
+    description: "Checkout fixture"
+    parameters:
+      repo:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: "Checkout fixture"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}
+            git clone https://github.com/GEOS-ESM/<< parameters.repo >>.git
+
+  mepoclone:
+    description: "Mepo clone external repos"
+    parameters:
+      repo:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: "Mepo clone external repos"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
+            mepo clone
+            mepo status
+
+  mepodevelop:
+    description: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
+    parameters:
+      repo:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
+            mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared
+            mepo status
+
+  cmake:
+    description: "Run CMake"
+    parameters:
+      repo:
+        type: string
+        default: ""
+      compiler:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: "Run CMake"
+          command: |
+            mkdir -p /logfiles
+            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
+            mkdir -p ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
+            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
+            cmake ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >> -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=<< parameters.compiler >> -DCMAKE_BUILD_TYPE=Debug -DUSE_F2PY=OFF -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS} -DCMAKE_INSTALL_PREFIX=${CIRCLE_WORKING_DIRECTORY}/workspace/install-<< parameters.repo >> |& tee /logfiles/cmake.log
+
+  buildinstall:
+    description: "Build and install"
+    parameters:
+      repo:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: "Build and install"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
+            make -j"$(nproc)" install |& tee /logfiles/make.log
+            #MEDIUM# make -j4 install |& tee /logfiles/make.log
+
+  checkout_cmake_branch:
+    description: "Mepo checkout ESMA_cmake branch"
+    parameters:
+      repo:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: "Mepo checkout ESMA_cmake branch"
+          command: |
+            mepo checkout ${CIRCLE_BRANCH} cmake
+            if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]
+            then
+                mepo checkout-if-exists ${CIRCLE_BRANCH}
+            fi
+            mepo status
+
 jobs:
   build-GEOSgcm:
-    executor: gcc-build-env
+    parameters:
+      compiler:
+        type: string
+    executor: << parameters.compiler >>
     working_directory: /root/project
     steps:
       - run:
           name: "ESMA_cmake branch"
           command: echo ${CIRCLE_BRANCH}
-      - checkout
-      - run:
-          name: "Checkout GEOSgcm fixture and update ESMA_cmake branch"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}
-            git clone git@github.com:GEOS-ESM/GEOSgcm.git
-            cd GEOSgcm
-            mepo clone
-            mepo develop GEOSgcm_GridComp GEOSgcm_App
-            if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "master" ] && [ "${CIRCLE_BRANCH}" != "main" ]
-            then
-               mepo checkout-if-exists ${CIRCLE_BRANCH}
-            fi
-            mepo status
-      - run:
-          name: "CMake"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm
-            mkdir build
-            cd build
-            cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_BUILD_TYPE=Debug -DUSE_F2PY=OFF
-      - run:
-          name: "Build"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm/build
-            make -j"$(nproc)" install
-            #MEDIUM# make -j4 install
+      - versions
+      - checkout_fixture:
+          repo: GEOSgcm
+      - mepoclone:
+          repo: GEOSgcm
+      - mepodevelop:
+          repo: GEOSgcm
+      - checkout_cmake_branch:
+          repo: GEOSgcm
+      - cmake:
+          repo: GEOSgcm
+          compiler: << parameters.compiler >>
+      - buildinstall:
+          repo: GEOSgcm
+      - store_artifacts:
+          path: /logfiles

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,8 @@ jobs:
       - run:
           name: "ESMA_cmake branch"
           command: echo ${CIRCLE_BRANCH}
-      - versions
+      - versions:
+          compiler: << parameters.compiler >>
       - checkout_fixture:
           repo: GEOSgcm
       - mepoclone:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ commands:
       - run:
           name: "Mepo checkout ESMA_cmake branch"
           command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
             mepo checkout ${CIRCLE_BRANCH} cmake
             if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]
             then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-## [3.7.0] - 2021-Oct-27
+## [3.7.0] - 2021-Nov-02
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.7.0] - 2021-Oct-27
+
+### Removed
+
+- Remove `find_package()` calls for GFE libraries from `FindBaselibs.cmake`
+
 ## [3.6.6] - 2021-Oct-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove `find_package()` calls for GFE libraries from `FindBaselibs.cmake`
 
+### Changed
+
+- Updated CI to use both gfortran and Intel, and Baselibs 6.2.8
+
 ## [3.6.6] - 2021-Oct-21
 
 ### Fixed

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -120,15 +120,6 @@ if (Baselibs_FOUND)
   set (INC_HDF ${BASEDIR}/include/hdf)
   set (INC_ESMF ${BASEDIR}/include/esmf)
 
-  find_package(GFTL REQUIRED)
-  find_package(GFTL_SHARED REQUIRED)
-  find_package(FARGPARSE QUIET)
-  find_package(YAFYAML REQUIRED)
-
-  option(BUILD_WITH_PFLOGGER "use pFlogger" ON)
-  if (BUILD_WITH_PFLOGGER)
-    find_package(PFLOGGER REQUIRED)
-  endif()
   # Need to do a bit of kludgy stuff here to allow Fortran linker to
   # find standard C and C++ libraries used by ESMF.
   # _And_ ESMF uses libc++ on some configs and libstdc++ on others.


### PR DESCRIPTION
Closes #233 

This removes `find_package()` calls for GFE libraries in `FindBaselibs.cmake`.

Keeping draft for now as this will need an update for MAPL as well (so we can find the packages)