### PR TITLE
Fixes #236. Move FindBaselibs up in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.7.1] - 2021-Nov-05
+
+### Fixed
+
+- Call `FindBaselibs.cmake` earlier in sequence. This sets the `CMAKE_PREFIX_PATH` before any `find_package()` calls for Baselibs libraries (i.e., GFE)
+
 ## [3.7.0] - 2021-Nov-02
 
 ### Removed

--- a/esma.cmake
+++ b/esma.cmake
@@ -47,6 +47,13 @@ include (ecbuild_system NO_POLICY_SCOPE)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/compiler")
 include (esma_compiler)
 
+### External Libraries Support ###
+
+list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external_libraries")
+include(math_libraries)
+include(FindBaselibs)
+find_package(GitInfo)
+
 ### ESMA Support ###
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/esma_support")
@@ -104,13 +111,6 @@ option (ESMA_USE_GFE_NAMESPACE "use cmake namespace with GFE projects" ON)
 
 set (XFLAGS "" CACHE STRING "List of extra FPP options that will be passed to select source files.")
 set (XFLAGS_SOURCES "" CACHE STRING "List of sources to which XFLAGS will be applied.")
-
-### External Libraries Support ###
-
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external_libraries")
-include(math_libraries)
-include(FindBaselibs)
-find_package(GitInfo)
 
 # On install, print 'Installing' but not 'Up-to-date' messages.
 set (CMAKE_INSTALL_MESSAGE LAZY)


### PR DESCRIPTION
Closes #236 

This PR moves the call for `FindBaselibs.cmake` up in the order of calls. This sets `CMAKE_PREFIX_PATH` earlier.

Blocking until I can do more tests to make sure.