### PR TITLE
Merge Develop into Main for Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.7.2] - 2021-Nov-08
+
+### Fixed
+
+- Move finding of OpenMP, MPI, and Threads above `FindBaselibs`. This was interfering with f2py...for some reason.
+
 ## [3.7.1] - 2021-Nov-05
 
 ### Fixed

--- a/esma.cmake
+++ b/esma.cmake
@@ -47,6 +47,34 @@ include (ecbuild_system NO_POLICY_SCOPE)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/compiler")
 include (esma_compiler)
 
+### OpenMP ###
+
+find_package (OpenMP)
+
+### Position independent code ###
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+### MPI Support ###
+
+# Only invoked from Fortran sources in GEOS-5,  But some BASEDIR packages use MPI from C/C++.
+set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
+find_package (MPI REQUIRED)
+
+### Threading ###
+
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+
+## Turns out with NAG on Linux, this generates '-pthread' which
+## NAG cannot handle. So we set to FALSE in that case
+if(UNIX AND CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+  set(THREADS_PREFER_PTHREAD_FLAG FALSE)
+else()
+  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+endif()
+
+find_package(Threads REQUIRED)
+
 ### External Libraries Support ###
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external_libraries")
@@ -75,35 +103,6 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/operating_system")
 if (APPLE)
   include(osx_extras)
 endif ()
-
-### OpenMP ###
-
-find_package (OpenMP)
-
-### Threading ###
-
-set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-
-## Turns out with NAG on Linux, this generates '-pthread' which
-## NAG cannot handle. So we set to FALSE in that case
-if(UNIX AND CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  set(THREADS_PREFER_PTHREAD_FLAG FALSE)
-else()
-  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-endif()
-
-find_package(Threads REQUIRED)
-
-### Position independent code ###
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-### MPI Support ###
-
-# Only invoked from Fortran sources in GEOS-5,  But some BASEDIR packages use MPI from C/C++.
-set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
-find_package (MPI REQUIRED)
-
 
 option (ESMA_ALLOW_DEPRECATED "suppress warnings about deprecated features" ON)
 # Temporary option for transition purposes.


### PR DESCRIPTION
Move a few more finds in `esma.cmake` up in the order. f2py calls were having issues with pthread and I think it was due to an order-of-operations.

Well, maybe. I dunno, this worked for me.