### PR TITLE
Fix git-stripped case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.7.3] - 2021-Dec-13
+
+### Fixed
+
+- Fix for `FindGitInfo` if in a git-stripped distribution
+
 ## [3.7.2] - 2021-Nov-08
 
 ### Fixed

--- a/external_libraries/FindGitInfo.cmake
+++ b/external_libraries/FindGitInfo.cmake
@@ -83,10 +83,13 @@ if(GIT_FOUND)
        WORKING_DIRECTORY ${dir}
        ERROR_VARIABLE GIT_error
        OUTPUT_VARIABLE ${prefix}_WC_REVISION_HASH
-       OUTPUT_STRIP_TRAILING_WHITESPACE)
+       OUTPUT_STRIP_TRAILING_WHITESPACE
+       ERROR_QUIET)
     set(${prefix}_WC_REVISION ${${prefix}_WC_REVISION_HASH})
     if(NOT ${GIT_error} EQUAL 0)
-      message(SEND_ERROR "Command \"${GIT_EXECUTBALE} rev-parse --verify -q --short=7 HEAD\" in directory ${dir} failed with output:\n${GIT_error}")
+      # We could be in a git-stripped tarball, so here we provide a "way out"
+      message(WARNING "Command \"${GIT_EXECUTABLE} rev-parse --verify -q --short=7 HEAD\" in directory ${dir} failed with output:\n${GIT_error}")
+      set(${prefix}_WC_LATEST_TAG "")
     else(NOT ${GIT_error} EQUAL 0)
       execute_process(COMMAND ${GIT_EXECUTABLE} name-rev ${${prefix}_WC_REVISION_HASH}
          WORKING_DIRECTORY ${dir}


### PR DESCRIPTION
There is a chance you could be in a git-stripped tarball. This change means the CMake step will not error out. That case is then covered upstream in the place that uses this macro.

Note: We only use the `_WC_LATEST_TAG` bit of this code, so that's what I 'protect' by setting it to a blank string. 