### PR TITLE
Changes to support using ESMA_cmake without needing MPI and Baselibs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Changes to support non-MPI and non-Baselibs builds
+   - Move `find_package(MPI REQUIRED)` code in `FindBaselibs.cmake` only if Baselibs found
+   - Remove code if not using Baselibs; should be placed in each fixture/directory
+
 ### Fixed
 ### Removed
 ### Added

--- a/esma.cmake
+++ b/esma.cmake
@@ -61,9 +61,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 ### MPI Support ###
 
-# Only invoked from Fortran sources in GEOS-5,  But some BASEDIR packages use MPI from C/C++.
-set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
-find_package (MPI REQUIRED)
+# MPI is now found in FindBaselibs
 
 ### Threading ###
 

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -14,6 +14,7 @@ endif ()
 # In CMake this is CMAKE_HOST_SYSTEM_NAME
 
 if (BASEDIR)
+  
   # First, what if we have a BASEDIR/lib, let's make sure it's like we want
   # That is, it has ARCH and it's the *right* ARCH!
   if (IS_DIRECTORY ${BASEDIR}/lib)
@@ -71,6 +72,10 @@ if (ESMA_SDF)
 endif ()
 
 if (Baselibs_FOUND)
+
+  # For now require MPI with Baselibs
+  set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
+  find_package(MPI REQUIRED)
 
   link_directories (${BASEDIR}/lib)
 
@@ -197,16 +202,24 @@ if (Baselibs_FOUND)
 
 else ()
 
-  find_package(NetCDF REQUIRED Fortran)
-  add_definitions(-DHAS_NETCDF4)
-  add_definitions(-DHAS_NETCDF3)
-  add_definitions(-DNETCDF_NEED_NF_MPIIO)
+  # These should be in each fixture
 
-  find_package(HDF5 REQUIRED)
-  if(HDF5_IS_PARALLEL)
-     add_definitions(-DH5_HAVE_PARALLEL)
-  endif()
-
-  find_package(ESMF MODULE REQUIRED)
+  ###########################################
+  # # For now require MPI with Baselibs     #
+  # set(MPI_DETERMINE_LIBRARY_VERSION TRUE) #
+  # find_package(MPI REQUIRED)              #
+  #                                         #
+  # find_package(NetCDF REQUIRED Fortran)   #
+  # add_definitions(-DHAS_NETCDF4)          #
+  # add_definitions(-DHAS_NETCDF3)          #
+  # add_definitions(-DNETCDF_NEED_NF_MPIIO) #
+  #                                         #
+  # find_package(HDF5 REQUIRED)             #
+  # if(HDF5_IS_PARALLEL)                    #
+  #    add_definitions(-DH5_HAVE_PARALLEL)  #
+  # endif()                                 #
+  #                                         #
+  # find_package(ESMF MODULE REQUIRED)      #
+  ###########################################
 
 endif()


### PR DESCRIPTION
This PR will track changes needed for using ESMA_cmake with codes that don't need MPI, netCDF, ESMF, etc.

This was spurred by the work of @amdasilva with AeroML which is (for the moment) pure Python/C/Fortran. No need for external libraries.

Note that I'll definitely be pinging @rmontuoro of UFS and @lizziel and @LiamBindle of Harvard as I work on this. I *think* they are actually good to go as they have shown @tclune and myself the right path forward.

Indeed, part of this PR is *undoing* some things I did for Spack work because, well, I was trying to be cute and clean. But sometimes CMake is ugly for good reasons!