### PR TITLE
Use FindESMF.cmake with Baselibs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Moved to use `find_package(ESMF)` for even use with Baselibs. This allows GEOS to more smoothly accept changes in ESMF builds by basing off of `esmf.mk`.
+- Changed `FindESMF.cmake` to prefer `SHARED` libraries over `STATIC` to match how ESMF-in-Baselibs worked before moving to `find_package`
+
 ### Fixed
 ### Removed
 ### Added

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -117,7 +117,6 @@ if (Baselibs_FOUND)
   set (INC_HDF5 ${BASEDIR}/include/hdf5)
   set (INC_NETCDF ${BASEDIR}/include/netcdf)
   set (INC_HDF ${BASEDIR}/include/hdf)
-  set (INC_ESMF ${BASEDIR}/include/esmf)
 
   # Need to do a bit of kludgy stuff here to allow Fortran linker to
   # find standard C and C++ libraries used by ESMF.
@@ -135,22 +134,13 @@ if (Baselibs_FOUND)
     execute_process (COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libdl.so OUTPUT_VARIABLE dl OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif ()
 
-  # With Baselibs 6.2.5, we can now link to the ESMF dynamic library on macOS
-  set (ESMF_LIBRARY esmf)
-  # Now set the suffix. Note that unfortunately CMAKE_SHARED_MODULE_SUFFIX doesn't
-  # quite do what we want (sets .so on macOS here), so we say "dylib" or "so"
-  if (APPLE)
-    set (ESMF_LIBRARY_SUFFIX "dylib")
+  if (NOT EXISTS ${BASEDIR}/lib/esmf.mk)
+    message (FATAL_ERROR "Cannot find ${ESMFMKFILE}")
   else ()
-    set (ESMF_LIBRARY_SUFFIX "so")
+    set (ESMFMKFILE "${BASEDIR}/lib/esmf.mk" CACHE PATH "Path to esmf.mk file" FORCE)
+    message(STATUS "ESMFMKFILE: ${ESMFMKFILE}")
   endif ()
-  set (ESMF_LIBRARY_PATH ${BASEDIR}/lib/lib${ESMF_LIBRARY}.${ESMF_LIBRARY_SUFFIX})
-
-  if (NOT EXISTS ${ESMF_LIBRARY_PATH})
-    message (FATAL_ERROR "Cannot find ${ESMF_LIBRARY_PATH}")
-  else ()
-    message(STATUS "ESMF_LIBRARY_PATH: ${ESMF_LIBRARY_PATH}")
-  endif ()
+  find_package(ESMF MODULE REQUIRED)
 
   set (NETCDF_LIBRARIES ${NETCDF_LIBRARIES_OLD})
 
@@ -167,9 +157,17 @@ if (Baselibs_FOUND)
   # We also need to append the pthread flag at link time
   list(APPEND NETCDF_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
 
-  set (ESMF_LIBRARIES ${ESMF_LIBRARY} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_CXX_LIBRARIES} ${rt} ${stdcxx} ${dl} ${libgcc})
-
   # Create targets
+  # - NetCDF C
+  add_library(NetCDF::NetCDF_C STATIC IMPORTED)
+  set_target_properties(NetCDF::NetCDF_C PROPERTIES
+    IMPORTED_LOCATION ${BASEDIR}/lib/libnetcdf.a
+    INTERFACE_INCLUDE_DIRECTORIES "${INC_NETCDF}"
+    INTERFACE_LINK_LIBRARIES  "${NETCDF_LIBRARIES}"
+    INTERFACE_LINK_DIRECTORIES "${BASEDIR}/lib"
+    )
+  set(NetCDF_C_FOUND TRUE CACHE BOOL "NetCDF C Found" FORCE)
+
   # - NetCDF Fortran
   add_library(NetCDF::NetCDF_Fortran STATIC IMPORTED)
   set_target_properties(NetCDF::NetCDF_Fortran PROPERTIES
@@ -179,16 +177,6 @@ if (Baselibs_FOUND)
     INTERFACE_LINK_DIRECTORIES "${BASEDIR}/lib"
     )
   set(NetCDF_Fortran_FOUND TRUE CACHE BOOL "NetCDF Fortran Found" FORCE)
-
-  # - ESMF
-  add_library(esmf STATIC IMPORTED)
-  set_target_properties(esmf PROPERTIES
-    IMPORTED_LOCATION ${ESMF_LIBRARY_PATH}
-    INTERFACE_INCLUDE_DIRECTORIES "${INC_ESMF}"
-    INTERFACE_LINK_LIBRARIES  "${ESMF_LIBRARIES}"
-    INTERFACE_LINK_DIRECTORIES "${BASEDIR}/lib"
-    )
-  set(esmf_FOUND TRUE CACHE BOOL "ESMF Found" FORCE)
 
   # BASEDIR.rc file does not have the arch
   string(REPLACE "/${CMAKE_SYSTEM_NAME}" "" BASEDIR_WITHOUT_ARCH ${BASEDIR})

--- a/external_libraries/FindESMF.cmake
+++ b/external_libraries/FindESMF.cmake
@@ -90,20 +90,22 @@ if(EXISTS ${ESMFMKFILE})
   endforeach()
   set(ESMF_F90COMPILEPATHS ${tmp})
 
-  # Look for static library, if not found try dynamic library
-  find_library(esmf_lib NAMES libesmf.a PATHS ${ESMF_LIBSDIR})
+  # Look for dynamic library, if not found try static library
+  # Also, prefer libesmf.so/dylib to the esmf_fullylinked library
+  #find_library(esmf_lib NAMES libesmf${CMAKE_SHARED_LIBRARY_SUFFIX} esmf_fullylinked PATHS ${ESMF_LIBSDIR})
+  find_library(esmf_lib NAMES esmf esmf_fullylinked PATHS ${ESMF_LIBSDIR})
   if(esmf_lib MATCHES "esmf_lib-NOTFOUND")
     unset(esmf_lib)
-    message(STATUS "Static ESMF library not found, searching for dynamic library instead")
-    find_library(esmf_lib NAMES esmf_fullylinked libesmf.so PATHS ${ESMF_LIBSDIR})
+    message(STATUS "Dynamic ESMF library not found, searching for static library instead")
+    find_library(esmf_lib NAMES libesmf.a PATHS ${ESMF_LIBSDIR})
     if(esmf_lib MATCHES "esmf_lib-NOTFOUND")
       unset(esmf_lib)
       message(STATUS "Neither the dynamic nor the static ESMF library was found")
     else()
-      set(_library_type SHARED)
+      set(_library_type STATIC)
     endif()
   else()
-    set(_library_type STATIC)
+    set(_library_type SHARED)
   endif()
 
   string(STRIP "${ESMF_F90ESMFLINKRPATHS} ${ESMF_F90ESMFLINKPATHS} ${ESMF_F90LINKPATHS} ${ESMF_F90LINKLIBS} ${ESMF_F90LINKOPTS}" ESMF_INTERFACE_LINK_LIBRARIES)


### PR DESCRIPTION
This PR moves ESMA_cmake to use `FindESMF.cmake` when running with Baselibs. This was motivated by @bena-nasa finding that GEOS did not like to build with recent ESMF where PIO has changed internally and now seems to be a required link with how we build ESMF (`ESMF_PIO=internal`). @rsdunlapiv has said that supporting PIO on places like discover would be good. 

Our current way of linking to ESMF-in-Baselibs is a bit _ad hoc_ and more based on historical ways of how we used to build in GNU days. It was...horrible and there are better ways.

So, now, we used `FindESMF.cmake` in conjunction with `esmf.mk` to get ESMF. Also, we alter the `FindESMF.cmake` in ESMA_cmake to prefer the shared object library over the static as this is how we are currently doing it.

NOTE: I'm keeping this draft until I can build a newer ESMF with `-lpioc` to make sure it actually solves the issue @bena-nasa found.