### PR TITLE
Add dependency to MPI for Baselibs ESMF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.15.1] - 2022-05-16
+
+### Fixed
+
+- Add dependency to MPI for ESMF when building with ESMF built within Baselibs.
+
 ## [3.15.0] - 2022-05-16
 
 ### Changed

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -156,6 +156,10 @@ if (Baselibs_FOUND)
     list (APPEND CMAKE_MODULE_PATH "${BASEDIR}/include/esmf")
     find_package(ESMF MODULE REQUIRED)
 
+    # Also, we know ESMF from Baselibs requires MPI (note that this isn't always true, but
+    # for ESMF built in Baselibs for use in GEOS, it currently is)
+    target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
+
     # Finally, we add an alias since GEOS (at the moment) uses esmf not ESMF for the target
     add_library(esmf ALIAS ESMF)
   endif ()


### PR DESCRIPTION
Testing building ADAS-only directories of GMAO_Shared (https://github.com/GEOS-ESM/GMAO_Shared/pull/262) showed that we need to tell CMake that ESMF depends on MPI when built in Baselibs. 