### PR TITLE
Changes needed to run GEOS on M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update M1 flags on GNU from GEOS testing
+- Also add M1-Rosetta2 flags from @climbfuji
 
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Update M1 flags on GNU from GEOS testing
+
 ### Fixed
 ### Removed
 ### Added

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -182,7 +182,7 @@ set (GEOS_Fortran_Vect_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
 # NOTE2: This uses -march=native so compile on your target architecture!!!
 
 # Options per Jerry DeLisle on GCC Fortran List
-if ( APPLE AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL arm64 )
+if (${proc_description} MATCHES "Apple M1" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
   # For now the only arm64 we have tested is Apple M1. This
   # might need to be revisited for M1 Max/Ultra and M2+.
   # Testing has not yet found any aggressive flags better than

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -112,9 +112,6 @@ set (NO_RANGE_CHECK "-fno-range-check")
 
 cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
 
-message (STATUS "proc_description: ${proc_description}")
-message (STATUS "CMAKE_HOST_SYSTEM_PROCESSOR: ${CMAKE_HOST_SYSTEM_PROCESSOR}")
-
 if ( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64 )
   set (GNU_TARGET_ARCH "armv8.2-a+crypto+crc+fp16+rcpc+dotprod")
   set (GNU_NATIVE_ARCH ${GNU_TARGET_ARCH})

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -110,25 +110,31 @@ set (NO_ALIAS "")
 
 set (NO_RANGE_CHECK "-fno-range-check")
 
-cmake_host_system_information(RESULT proc_decription QUERY PROCESSOR_DESCRIPTION)
+cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
+
+message (STATUS "proc_description: ${proc_description}")
+message (STATUS "CMAKE_HOST_SYSTEM_PROCESSOR: ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 
 if ( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64 )
   set (GNU_TARGET_ARCH "armv8.2-a+crypto+crc+fp16+rcpc+dotprod")
   set (GNU_NATIVE_ARCH ${GNU_TARGET_ARCH})
-elseif ( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL arm64 )
-  # For now the only arm64 we have tested is Apple M1. This
-  # might need to be revisited for M1 Max/Ultra and M2+.
-  # Also, fail if a Linux Arm64. Testing show GEOS fails 
-  # with -march=native
-  if (APPLE)
+elseif (${proc_description} MATCHES "Apple M1")
+  if (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
+    # Testing show GEOS fails with -march=native on M1 in native mode
     set (GNU_TARGET_ARCH "armv8-a")
     set (GNU_NATIVE_ARCH ${GNU_TARGET_ARCH})
+  elseif (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    # Rosetta2 flags per tests by @climbfuji
+    set (GNU_TARGET_ARCH "westmere")
+    set (GNU_NATIVE_ARCH "native")
+    set (PREFER_AVX128 "-mprefer-avx128")
+    set (NO_FMA "-mno-fma")
   endif ()
-elseif (${proc_decription} MATCHES "EPYC")
+elseif (${proc_description} MATCHES "EPYC")
   set (GNU_TARGET_ARCH "znver2")
   set (GNU_NATIVE_ARCH "native")
   set (NO_FMA "-mno-fma")
-elseif (${proc_decription} MATCHES "Intel")
+elseif (${proc_description} MATCHES "Intel")
   set (GNU_TARGET_ARCH "westmere")
   set (GNU_NATIVE_ARCH "native")
   set (PREFER_AVX128 "-mprefer-avx128")

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -47,10 +47,10 @@ set (USE_SVML "-fimf-use-svml=true")
 
 set (NO_RANGE_CHECK "")
 
-cmake_host_system_information(RESULT proc_decription QUERY PROCESSOR_DESCRIPTION)
-if (${proc_decription} MATCHES "EPYC")
+cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
+if (${proc_description} MATCHES "EPYC")
   set (COREAVX2_FLAG "-march=core-avx2")
-elseif (${proc_decription} MATCHES "Intel")
+elseif (${proc_description} MATCHES "Intel")
   set (COREAVX2_FLAG "-march=core-avx2")
   # Previous versions of GEOS used this flag, which was not portable
   # for AMD. Keeping here for a few versions for historical purposes.


### PR DESCRIPTION
This is a tracking branch for M1 support of GEOS. 

Current testing (with generous help from @iains), see:

https://github.com/GEOS-ESM/GEOSgcm/issues/417

has shown that GEOS seems to not be happy with `-march=native` and whatever other flags we do for Aggressive. So, for now, we just make our Aggressive build match that of Release. Testing shows the Release flags seem to be pretty darn good so it's not like we are missing much.