### PR TITLE
Add more ignores to CPack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # Anchors to prevent forgetting to update a version
 baselibs_version: &baselibs_version v7.5.0
-bcs_version: &bcs_version v10.22.3
+bcs_version: &bcs_version v10.22.5
 
 orbs:
   ci: geos-esm/circleci-tools@1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated the CI to work with latest Baselibs
+- Updated the list of files ignored by CPack
 
 ### Removed
 ### Added

--- a/esma_cpack.cmake
+++ b/esma_cpack.cmake
@@ -13,6 +13,12 @@ set(CPACK_SOURCE_IGNORE_FILES
   /.mepo/
   /build.*/
   /install.*/
+  /CVS/
+  .\*.swp
+  .\*.swo
+  .\*~
+  .\*\#
+  \.DS_Store
 )
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}")
 # Note we need to call this again to "overwrite" the CPack done in ecbuild


### PR DESCRIPTION
This PR attempts to fix a weird CPack issue reported by @sdrabenh and @Jcampbell-8. I think the issue is that an editor has made a tempfile in the model that is seen by CMake at CMake time. But by the time CPack runs at the end, the tempfile is gone causing a fault.

So, we add various tempfile patterns to `CPACK_SOURCE_IGNORE_FILES` to fix this.