### PR TITLE
Update Intel Fortran Debugging flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved to use GitHub Actions for label enforcement
-- Add extra flags for Intel Fortran Debug allow for stricter builds (note not enabled by default for all builds)
+- Add extra flags for Intel Fortran to allow for stricter builds
   - `-stand f18` to enable Fortran 2018 Standard compliance
   - `-diag-error 6188` to cause if(integer) to fail
   - `-diag-error 6192` to cause logical set to integer to fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved to use GitHub Actions for label enforcement
-- Add extra flags to Intel Fortran Debug builds to make them stricter
+- Add extra flags for Intel Fortran Debug allow for stricter builds (note not enabled by default for all builds)
   - `-stand f18` to enable Fortran 2018 Standard compliance
   - `-diag-error 6188` to cause if(integer) to fail
   - `-diag-error 6192` to cause logical set to integer to fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved to use GitHub Actions for label enforcement
+- Add extra flags to Intel Fortran Debug builds to make them stricter
+  - `-stand f18` to enable Fortran 2018 Standard compliance
+  - `-diag-error 6188` to cause if(integer) to fail
+  - `-diag-error 6192` to cause logical set to integer to fail
+  - `-diag-disable 5268` to suppress warning for long source lines (which our macros often make)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Removed
+
+### Added
+
+## [3.22.0] - 2022-12-13
+
+### Changed
+
 - Moved to use GitHub Actions for label enforcement
 - Add extra flags for Intel Fortran to allow for stricter builds
   - `-stand f18` to enable Fortran 2018 Standard compliance
   - `-diag-error 6188` to cause if(integer) to fail
   - `-diag-error 6192` to cause logical set to integer to fail
   - `-diag-disable 5268` to suppress warning for long source lines (which our macros often make)
-
-### Fixed
-
-### Removed
-
-### Added
 
 ## [3.21.0] - 2022-11-28
 

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -83,7 +83,7 @@ set (common_Fortran_fpe_flags "${FPE0} ${FP_MODEL_SOURCE} ${HEAPARRAYS} ${NOOLD_
 
 # GEOS Debug
 # ----------
-set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check all,noarg_temp_created -fp-stack-check -warn unused -init=snan,arrays -save-temps ${STANDARDS_FLAGS}")
+set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check all,noarg_temp_created -fp-stack-check -warn unused -init=snan,arrays -save-temps")
 set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 
 # GEOS NoVectorize

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -53,10 +53,7 @@ set (ERROR_IF_INTEGER "-diag-error 6188")
 ## Error out if you try to set a logical to an integer
 set (ERROR_LOGICAL_SET_TO_INTEGER "-diag-error 6192")
 ## Turn off warning #5268 (Extension to standard: The text exceeds right hand column allowed on the line.)
-set (DISABLE_5268 "-diag-disable 5268")
-
-## Create a omnibus flag for all the flags above
-set (STANDARDS_FLAGS "${STANDARD_F18} ${ERROR_IF_INTEGER} ${ERROR_LOGICAL_SET_TO_INTEGER} ${DISABLE_5268}")
+set (DISABLE_LONG_LINE_LENGTH_WARNING "-diag-disable 5268")
 
 set (NO_RANGE_CHECK "")
 

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -45,6 +45,19 @@ set (ALIGN_ALL "-align all")
 set (NO_ALIAS "-fno-alias")
 set (USE_SVML "-fimf-use-svml=true")
 
+# Additional flags for better Standards compliance
+## Set the Standard to be Fortran 2018
+set (STANDARD_F18 "-stand f18")
+## Error out if you try to do if(integer)
+set (ERROR_IF_INTEGER "-diag-error 6188")
+## Error out if you try to set a logical to an integer
+set (ERROR_LOGICAL_SET_TO_INTEGER "-diag-error 6192")
+## Turn off warning #5268 (Extension to standard: The text exceeds right hand column allowed on the line.)
+set (DISABLE_5268 "-diag-disable 5268")
+
+## Create a omnibus flag for all the flags above
+set (STANDARDS_FLAGS "${STANDARD_F18} ${ERROR_IF_INTEGER} ${ERROR_LOGICAL_SET_TO_INTEGER} ${DISABLE_5268}")
+
 set (NO_RANGE_CHECK "")
 
 cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
@@ -70,7 +83,7 @@ set (common_Fortran_fpe_flags "${FPE0} ${FP_MODEL_SOURCE} ${HEAPARRAYS} ${NOOLD_
 
 # GEOS Debug
 # ----------
-set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check all,noarg_temp_created -fp-stack-check -warn unused -init=snan,arrays -save-temps")
+set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check all,noarg_temp_created -fp-stack-check -warn unused -init=snan,arrays -save-temps ${STANDARDS_FLAGS}")
 set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 
 # GEOS NoVectorize


### PR DESCRIPTION
Closes #296 

This PR adds extra flags to Intel Fortran Debug builds to make them stricter:
  - `-stand f18` to enable Fortran 2018 Standard compliance
  - `-diag-error 6188` to cause if(integer) to fail
  - `-diag-error 6192` to cause logical set to integer to fail
  - `-diag-disable 5268` to suppress warning for long source lines (which our macros often make)