### PR TITLE
Remove BUILT_ON_ROME detection at NAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove `BUILT_ON_ROME` detection at NAS
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Remove `BUILT_ON_ROME` detection at NAS
-
 ### Fixed
 
 ### Removed
 
 ### Added
+
+## [3.29.0] - 2023-05-18
+
+### Changed
+
+- Remove `BUILT_ON_ROME` detection at NAS as all nodes are now TOSS4
 
 ## [3.28.0] - 2023-03-23
 

--- a/external_libraries/DetermineSite.cmake
+++ b/external_libraries/DetermineSite.cmake
@@ -11,15 +11,8 @@ set(DETECTED_SITE "UNKNOWN")
 
 if (${BUILD_SITE} MATCHES "discover*" OR ${BUILD_SITE} MATCHES "borg*" OR ${BUILD_SITE} MATCHES "warp*")
   set (DETECTED_SITE "NCCS")
-# At NAS, if you want to run on Rome, you have to build on Rome due to
-# OS differences. So we make a variable that can let us make the setup
-# scripts aware of this.
-elseif (${BUILD_SITE} MATCHES "pfe" OR ${BUILD_SITE} MATCHES "r[0-9]*i[0-9]*n[0-9]*")
+elseif (${BUILD_SITE} MATCHES "pfe" OR ${BUILD_SITE} MATCHES "r[0-9]*i[0-9]*n[0-9]*" OR ${BUILD_SITE} MATCHES "r[0-9]*c[0-9]*t[0-9]*n[0-9]*")
   set (DETECTED_SITE "NAS")
-  set (BUILT_ON_ROME FALSE)
-elseif (${BUILD_SITE} MATCHES "r[0-9]*c[0-9]*t[0-9]*n[0-9]*")
-  set (DETECTED_SITE "NAS")
-  set (BUILT_ON_ROME TRUE)
 elseif (EXISTS /ford1/share/gmao_SIteam AND EXISTS /ford1/local AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set (DETECTED_SITE "GMAO.desktop")
 endif ()
@@ -70,13 +63,4 @@ endif ()
 
 set(GEOS_SITE ${DETECTED_SITE} CACHE STRING "Detected site for use with GEOS setup scripts")
 message(STATUS "Setting GEOS_SITE to ${GEOS_SITE}")
-
-# Add message to say where we built at NAS
-if (DETECTED_SITE STREQUAL "NAS")
-  if (BUILT_ON_ROME)
-    message(STATUS "Building on AMD Rome nodes at NAS")
-  else()
-    message(STATUS "Building on Intel nodes at NAS")
- endif()
-endif()
 


### PR DESCRIPTION
With NAS moving all of its systems to TOSS4, the "detect if Rome" bits of ESMA_cmake can be removed. 

This PR is in concert with https://github.com/GEOS-ESM/GEOSgcm_App/pull/460