### PR TITLE
Update GNU Release Flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+- Changed GNU Release flags to use `-O2` to work around issue at NAS on
+  TOSS4 (see #317)
+- Updated supported GNU flag to 11.3
+
 ## [3.29.0] - 2023-05-18
 
 ### Changed

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -1,4 +1,4 @@
-if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 8.3)
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 11.3)
   message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 8.3!")
 endif()
 
@@ -159,7 +159,7 @@ set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 
 # GEOS Release
 # ------------
-set (GEOS_Fortran_Release_Flags "${FOPT3} -march=${GNU_TARGET_ARCH} -mtune=generic -funroll-loops ${DEBINFO}")
+set (GEOS_Fortran_Release_Flags "${FOPT2} -march=${GNU_TARGET_ARCH} -mtune=generic -funroll-loops ${DEBINFO}")
 set (GEOS_Fortran_Release_FPE_Flags "${common_Fortran_fpe_flags}")
 
 # Create a NoVectorize version for consistency. No difference from Release for GNU


### PR DESCRIPTION
Testing at NAS seems to show that moving from `-O3` to `-O2` fixes issues with TOSS4.

cc: @gmao-rreichle that GNU results might change in the pursuit of portability between centers...