### PR TITLE
Suppress some useless warnings at all times with Intel Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [3.31.0] - 2023-07-25
+
+### Changed
+
+- Suppress common unneeded warnings with all debug builds with Intel
+
 ## [3.30.0] - 2023-06-23
 
 ### Added

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -85,7 +85,7 @@ if (QUIET_DEBUG)
   set (SUPPRESS_COMMON_WARNINGS "${DISABLE_FIELD_WIDTH_WARNING} ${DISABLE_GLOBAL_NAME_WARNING} ${DISABLE_10337}")
 else ()
   set (WARN_UNUSED "-warn unused")
-  set (SUPPRESS_COMMON_WARNINGS "")
+  set (SUPPRESS_COMMON_WARNINGS "${DISABLE_GLOBAL_NAME_WARNING} ${DISABLE_10337}")
 endif ()
 
 ####################################################


### PR DESCRIPTION
The "global name warning":
```
/discover/nobackup/mathomp4/SystemTests/builds/AGCM/CURRENT/GEOSgcm/src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/Shared/HEMCO/@HEMCO/src/Core/hcoio_read_esmf_mod.F90: warning #5462: Global name too long, shortened from: hcoio_read_esmf_mod_mp_hcoio_read_esmf_$blk.pfio_netcdf4_fileformattermod_mp_mpi_statuses_ignore_ to: coio_read_esmf_mod_mp_hcoio_read_esmf_$blk.pfio_netcdf4_fileformattermod_mp_mpi_statuses_ignore_
# 1 "/discover/nobackup/mathomp4/SystemTests/builds/AGCM/CURRENT/GEOSgcm/src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/Shared/HEMCO/@HEMCO/src/Core/hcoio_read_esmf_mod.F90"
```
and the "10337" warning:
```
ifort: warning #10337: option '-fno-builtin' disables '-imf*' option
```
are pretty much never useful. So let's suppress them at all times when building Intel Debug. Users can't really do anything about them, so why annoy the user.