### PR TITLE
Add needed flag for icx builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add setting `-Wno-implicit-int` when running with `icx`
+
 ### Changed
 
 ## [3.35.0] - 2023-10-13

--- a/compiler/esma_compiler.cmake
+++ b/compiler/esma_compiler.cmake
@@ -12,8 +12,6 @@ include(check_fortran_support)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/flags")
 include ("${CMAKE_Fortran_COMPILER_ID}_Fortran")
 
-message(STATUS "CMAKE_C_COMPILER_ID: ${CMAKE_C_COMPILER_ID}")
-
 ## We need to append some extra flags if using icx (aka CMAKE_C_COMPILER_ID=IntelLLVM)
 if (CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-int")

--- a/compiler/esma_compiler.cmake
+++ b/compiler/esma_compiler.cmake
@@ -11,3 +11,10 @@ include(check_fortran_support)
 ## Files with flags for Fortran compilers
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/flags")
 include ("${CMAKE_Fortran_COMPILER_ID}_Fortran")
+
+message(STATUS "CMAKE_C_COMPILER_ID: ${CMAKE_C_COMPILER_ID}")
+
+## We need to append some extra flags if using icx (aka CMAKE_C_COMPILER_ID=IntelLLVM)
+if (CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-int")
+endif ()


### PR DESCRIPTION
Testing with Intel Fortran Classic 2021.10 found that we need a new flag `-Wno-implicit-int` when using `icx` because the Intel oneAPI 2023.2 module at NCCS uses `icx` as the C compiler.