### PR TITLE
Fixes for Intel Rosetta under Clang 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [3.36.0] - 2023-10-26
+
+### Fixed
+
+- Fixes for building with Intel Fortran Classic on macOS on Arm under Clang 15 and Rosetta
+  - Uses `ld_classic` as the linker
+
 ## [3.35.0] - 2023-10-13
 
 ### Added

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -78,6 +78,11 @@ elseif (${proc_description} MATCHES "Intel")
 elseif ( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64" )
   message(WARNING "Unknown processory type. Defaulting to a generic x86_64 processor. Performance may be suboptimal.")
   set (COREAVX2_FLAG "")
+  # Once you are in here, you are probably on Rosetta, but not required. 
+  # Still, on Apple Rosetta we also now need to use the ld_classic as the linker
+  if (APPLE)
+    add_link_options("-Wl,-ld_classic")
+  endif ()
 else ()
   message(FATAL_ERROR "Unknown processor. Please file an issue at https://github.com/GEOS-ESM/ESMA_cmake")
 endif ()


### PR DESCRIPTION
This pulls in a fix from @tclune for building on macOS under Rosetta.