### PR TITLE
WIP: Updates for ifx support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updates for ifx support
+  - Updated `IntelLLVM_Fortran.cmake` to match `Intel_Fortran.cmake`
+  - Added `nouninit` to flags because of [this ifx allocatable bug](https://github.com/HPC-Bugs/reproducers/tree/main/compiler/Fortran/ifx/allocatable)  
+
 ## [3.36.0] - 2023-10-26
 
 ### Fixed


### PR DESCRIPTION
Now that we have Intel 2021.10 support (ish), we need to start looking at `ifx` instead of `ifort`.

This PR first moves the `IntelLLVM` flags up to match the `Intel` ones (as a start). Next we unset `-check uninit` due to the allocatable bug found by @everythingfunctional:

https://github.com/HPC-Bugs/reproducers/tree/main/compiler/Fortran/ifx/allocatable

I'll also look at the OpenMP issue raised by @dkokron in the MAPL issue:

https://github.com/GEOS-ESM/MAPL/issues/1890