### PR TITLE
Set BUILT_ON_SLES15 to FALSE if not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Set `BUILT_ON_SLES15` to `FALSE` if not building on SLES15. Before it was blank
-
 ### Removed
 
 ### Added
@@ -18,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Deprecated
+
+## [3.44.0] - 2024-03-29
+
+### Fixed
+
+- Set `BUILT_ON_SLES15` to `FALSE` if not building on SLES15. Before it was blank
 
 ## [3.43.0] - 2024-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [3.36.1] - 2023-12-12
+
+### Fixed
+
+- Set `BUILT_ON_SLES15` to `FALSE` if not building on SLES15. Before it was blank
+
 ## [3.36.0] - 2023-10-26
 
 ### Fixed

--- a/external_libraries/DetermineSite.cmake
+++ b/external_libraries/DetermineSite.cmake
@@ -25,6 +25,8 @@ if (${BUILD_SITE} MATCHES "discover*" OR ${BUILD_SITE} MATCHES "borg*" OR ${BUIL
     )
   if (OS_RELEASE STREQUAL "15")
     set (BUILT_ON_SLES15 TRUE)
+  else ()
+    set (BUILT_ON_SLES15 FALSE)
   endif ()
 elseif (${BUILD_SITE} MATCHES "pfe" OR ${BUILD_SITE} MATCHES "r[0-9]*i[0-9]*n[0-9]*" OR ${BUILD_SITE} MATCHES "r[0-9]*c[0-9]*t[0-9]*n[0-9]*")
   set (DETECTED_SITE "NAS")


### PR DESCRIPTION
As found by @weiyuan-jiang I was lazy and if you were at NCCS and did not build on SLES15, `BUILT_ON_SLES15` was not `FALSE` but empty. This is less than ideal just in case blank is a truthy value.

Note: This depends on fixing code in GEOS_Util (see https://github.com/GEOS-ESM/GEOS_Util/pull/66)