### PR TITLE
Turn off ESMF_HAS_ACHAR_BUG for NAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Set `nouninit` for check flags when building with Debug build type
   - Remove some debug flags that don't exist with `ifx`
   - Remove `-init=snan` as that causes compiler faults with some MAPL files
+- For NAG, turn of setting of `ESMF_HAS_ACHAR_BUG` CMake option as it seems
+  no longer needed
 
 ## [3.36.0] - 2023-10-26
 

--- a/compiler/flags/NAG_Fortran.cmake
+++ b/compiler/flags/NAG_Fortran.cmake
@@ -16,7 +16,7 @@ set (F2018 "-f2018")
 set (OPENMP "-not_openmp")
 
 if (APPLE)
-  option (ESMF_HAS_ACHAR_BUG "ESMF Compatibility issue" ON)
+  option (ESMF_HAS_ACHAR_BUG "ESMF Compatibility issue" OFF)
 endif ()
 
 ####################################################


### PR DESCRIPTION
Tests by @metdyn and myself seem to indicate the `ESMF_HAS_ACHAR_BUG` CMake option is no longer needed for NAG. Indeed, turning it on seems to break ExtData tests (at least).

Will consult with @tclune (and maybe ESMF) before committing and releasing.