### PR TITLE
Updates to enable jemalloc build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `FindJeMalloc.cmake` for use with builds of GEOSgcm
+
 ### Changed
 
 - Update CI to v2 orb


### PR DESCRIPTION
This PR has updates necessary to build GEOS with jemalloc. It adds an option `USE_JEMALLOC` that by default is `OFF`.