### PR TITLE
Add ESMF::ESMF Alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ESMF::ESMF` alias for ESMF library
   - Needed to avoid an issue UFS has with MAPL/GOCART
   - Needed for Baselibs builds of MAPL 2.44 and higher as we now move to use `ESMF::ESMF` as the target
+  - Will be added to `FindESMF.cmake` in a future release of ESMF, so we only add the alias if it doesn't exist
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+## [3.39.0] - 2024-02-06
+
+### Added
+
 - Added `ESMF::ESMF` alias for ESMF library
   - Needed to avoid an issue UFS has with MAPL/GOCART
   - Needed for Baselibs builds of MAPL 2.44 and higher as we now move to use `ESMF::ESMF` as the target
@@ -20,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update CI to v2 orb
-
-### Deprecated
 
 ## [3.38.0] - 2024-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `ESMF::ESMF` alias for ESMF library
-  - Needed to avoid an issue UFS has with MAPL/GOCART
+  - Needed to avoid an issue UFS has with MAPL/GOCART (see https://github.com/GEOS-ESM/MAPL/issues/2569)
   - Needed for Baselibs builds of MAPL 2.44 and higher as we now move to use `ESMF::ESMF` as the target
   - Will be added to `FindESMF.cmake` in a future release of ESMF, so we only add the alias if it doesn't exist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `ESMF::ESMF` alias for ESMF library
+  - Needed to avoid an issue UFS has with MAPL/GOCART
+  - Needed for Baselibs builds of MAPL 2.44 and higher as we now move to use `ESMF::ESMF` as the target
+
 ### Changed
 
 - Update CI to v2 orb

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -163,7 +163,13 @@ if (Baselibs_FOUND)
 
     # Finally, we add an alias since GEOS (at the moment) uses esmf not ESMF for the target
     add_library(esmf ALIAS ESMF)
-    add_library(ESMF::ESMF ALIAS ESMF)
+
+    # We also add an alias for the target ESMF::ESMF. This will eventually be
+    # added to `FindESMF.cmake` in ESMF, but for now we do it here. To be safe,
+    # we only add the alias if it doesn't already exist.
+    if (NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF ALIAS ESMF)
+    endif ()
   endif ()
 
   # ------

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -163,6 +163,7 @@ if (Baselibs_FOUND)
 
     # Finally, we add an alias since GEOS (at the moment) uses esmf not ESMF for the target
     add_library(esmf ALIAS ESMF)
+    add_library(ESMF::ESMF ALIAS ESMF)
   endif ()
 
   # ------


### PR DESCRIPTION
This PR adds an `ESMF::ESMF` alias to builds using Baselibs. This is needed for UFS builds of MAPL/GOCART, see https://github.com/GEOS-ESM/MAPL/issues/2569

This also means that this upcoming version of ESMA_cmake (v3.39.0) will be required by MAPL 2.44 when all changes are in.