### PR TITLE
Update FindESMF.cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.40.0] - 2024-02-06
+
+### Changed
+
+- Updated `FindESMF.cmake` to the version from ESMF develop branch, commit da8f410. Will be in ESMF 8.6.1+
+  - This provides the `ESMF::ESMF` alias for ESMF library for non-Baselibs builds
+
 ## [3.39.0] - 2024-02-06
 
 ### Added

--- a/external_libraries/FindESMF.cmake
+++ b/external_libraries/FindESMF.cmake
@@ -109,6 +109,11 @@ if(EXISTS ${ESMFMKFILE})
     endif()
   endif()
 
+  # Add target alias to facilitate unambiguous linking
+  if(NOT TARGET ESMF::ESMF)
+    add_library(ESMF::ESMF ALIAS ESMF)
+  endif()
+
   # Add ESMF include directories
   set(ESMF_INCLUDE_DIRECTORIES "")
   separate_arguments(_ESMF_F90COMPILEPATHS UNIX_COMMAND ${ESMF_F90COMPILEPATHS})


### PR DESCRIPTION
In #350 I forgot to update the `FindESMF.cmake` file to provide the `ESMF::ESMF` alias for non-Baselibs builds of GEOS.