### PR TITLE
Update FindESMF.cmake to make ESMF::ESMF main target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.40.1] - 2024-02-12
+
+### Fixed
+
+- Edit `FindESMF.cmake` to use `ESMF::ESMF` as the primary target and make `ESMF` an alias for `ESMF::ESMF` if it doesn't exist
+
 ## [3.40.0] - 2024-02-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Updates for building with Clang on macOS
-  - Add `-Wl,-ld_classic` to linker flags for all macOS
-  - Add `-Wno-implicit-int` for Clang on macOS
-- Fix for using f2py and Python 3.12
-
 ### Removed
 
 ### Added
-
-- Add suppression of remark 10488 for Intel Fortran Classic which is a warning about ifort deprecation in late 2024
 
 ### Changed
 
 ### Deprecated
 
-## [3.45.0] - 2024-04-XX
+## [3.45.0] - 2024-04-25
 
 ### Fixed
 
 - Edit `FindESMF.cmake` to use `ESMF::ESMF` as the primary target and make `ESMF` an alias for `ESMF::ESMF` if it doesn't exist
+- Updates for building with Clang on macOS
+  - Add `-Wl,-ld_classic` to linker flags for all macOS
+  - Add `-Wno-implicit-int` for Clang on macOS
+- Fix for using f2py and Python 3.12
+
+### Added
+
+- Add suppression of remark 10488 for Intel Fortran Classic which is a warning about ifort deprecation in late 2024
 
 ## [3.44.0] - 2024-03-29
 

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -14,7 +14,7 @@ endif ()
 # In CMake this is CMAKE_HOST_SYSTEM_NAME
 
 if (BASEDIR)
-  
+
   # First, what if we have a BASEDIR/lib, let's make sure it's like we want
   # That is, it has ARCH and it's the *right* ARCH!
   if (IS_DIRECTORY ${BASEDIR}/lib)
@@ -164,8 +164,14 @@ if (Baselibs_FOUND)
 
     # Finally, we add aliases since GEOS (at the moment) uses esmf and ESMF for the target
     # instead of ESMF::ESMF (MAPL uses ESMF::ESMF)
-    add_library(ESMF ALIAS ESMF::ESMF)
-    add_library(esmf ALIAS ESMF::ESMF)
+    if (NOT TARGET ESMF)
+      message(STATUS "ESMF alias not found, creating ESMF alias")
+      add_library(ESMF ALIAS ESMF::ESMF)
+    endif ()
+    if (NOT TARGET esmf)
+      message(STATUS "esmf alias not found, creating esmf alias")
+      add_library(esmf ALIAS ESMF::ESMF)
+    endif ()
   endif ()
 
   # ------

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -153,23 +153,19 @@ if (Baselibs_FOUND)
     set (ESMFMKFILE "${BASEDIR}/lib/esmf.mk" CACHE PATH "Path to esmf.mk file" FORCE)
     message(STATUS "ESMFMKFILE: ${ESMFMKFILE}")
 
-    # Now, let us use the FindESMF.cmake that ESMF itself includes and installs
-    list (APPEND CMAKE_MODULE_PATH "${BASEDIR}/include/esmf")
+    # Now we can use FindESMF.cmake to find ESMF. This uses the one in the current
+    # directory, not the one in the ESMF installation. The one here uses
+    # ESMF::ESMF as the main target
     find_package(ESMF MODULE REQUIRED)
 
     # Also, we know ESMF from Baselibs requires MPI (note that this isn't always true, but
     # for ESMF built in Baselibs for use in GEOS, it currently is)
-    target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
+    target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
 
-    # Finally, we add an alias since GEOS (at the moment) uses esmf not ESMF for the target
-    add_library(esmf ALIAS ESMF)
-
-    # We also add an alias for the target ESMF::ESMF. This will eventually be
-    # added to `FindESMF.cmake` in ESMF, but for now we do it here. To be safe,
-    # we only add the alias if it doesn't already exist.
-    if (NOT TARGET ESMF::ESMF)
-      add_library(ESMF::ESMF ALIAS ESMF)
-    endif ()
+    # Finally, we add aliases since GEOS (at the moment) uses esmf and ESMF for the target
+    # instead of ESMF::ESMF (MAPL uses ESMF::ESMF)
+    add_library(ESMF ALIAS ESMF::ESMF)
+    add_library(esmf ALIAS ESMF::ESMF)
   endif ()
 
   # ------

--- a/external_libraries/FindESMF.cmake
+++ b/external_libraries/FindESMF.cmake
@@ -109,7 +109,7 @@ if(EXISTS ${ESMFMKFILE})
     endif()
   endif()
 
-  # Add target alias to facilitate unambiguous linking
+  # Add ESMF as an alias to ESMF::ESMF for backward compatibility
   if(NOT TARGET ESMF)
     add_library(ESMF ALIAS ESMF::ESMF)
   endif()

--- a/external_libraries/FindESMF.cmake
+++ b/external_libraries/FindESMF.cmake
@@ -96,22 +96,22 @@ if(EXISTS ${ESMFMKFILE})
       message(WARNING "Static ESMF library (libesmf.a) not found in \
                        ${ESMF_LIBSDIR}. Try setting USE_ESMF_STATIC_LIBS=OFF")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF STATIC IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF STATIC IMPORTED)
     endif()
   else()
     find_library(ESMF_LIBRARY_LOCATION NAMES esmf PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
     if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
       message(WARNING "ESMF library not found in ${ESMF_LIBSDIR}.")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF UNKNOWN IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF UNKNOWN IMPORTED)
     endif()
   endif()
 
   # Add target alias to facilitate unambiguous linking
-  if(NOT TARGET ESMF::ESMF)
-    add_library(ESMF::ESMF ALIAS ESMF)
+  if(NOT TARGET ESMF)
+    add_library(ESMF ALIAS ESMF::ESMF)
   endif()
 
   # Add ESMF include directories
@@ -135,7 +135,7 @@ if(EXISTS ${ESMFMKFILE})
                       ESMF_F90COMPILEPATHS
         VERSION_VAR ESMF_VERSION)
 
-  set_target_properties(ESMF PROPERTIES
+  set_target_properties(ESMF::ESMF PROPERTIES
         IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
         INTERFACE_INCLUDE_DIRECTORIES "${ESMF_INCLUDE_DIRECTORIES}"
         INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")


### PR DESCRIPTION
This updates `FindESMF.cmake` to make `ESMF::ESMF` the main target and `ESMF` an alias.

Related: https://github.com/GEOS-ESM/MAPL/pull/2682