### PR TITLE
Use CMake to determine MPI Stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added new `DetermineMPIStack.cmake` file that will detect the MPI Stack being used
+  - The allowed stacks are `openmpi`, `mpich`, `intel`, `mvapich`, `mpt` which will
+    be set in the `MPI_STACK` variable
+    - Can be overridden by setting `MPI_STACK` to one of the allowed values via `-DMPI_STACK=...`
+  - Will also set `MPI_STACK_VERSION` to the version of the stack being used
+    - NOTE: This is the version of the *stack* not the version of MPI supported by the stack 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added new `DetermineMPIStack.cmake` file that will detect the MPI Stack being used
+
 ### Changed
 
 ### Deprecated

--- a/esma.cmake
+++ b/esma.cmake
@@ -62,6 +62,7 @@ include(math_libraries)
 include(FindBaselibs)
 include(DetermineSite)
 find_package(GitInfo)
+include(DetermineMPIStack)
 
 ### ESMA Support ###
 

--- a/external_libraries/DetermineMPIStack.cmake
+++ b/external_libraries/DetermineMPIStack.cmake
@@ -1,0 +1,60 @@
+# This code will try and determine the MPI stack being used and set the MPI_STACK variable
+
+include(CMakePrintHelpers)
+
+set(ALLOWED_MPI_STACKS "intelmpi;mvapich;mpt;mpich;openmpi")
+
+if (MPI_STACK)
+  if (NOT MPI_STACK IN_LIST ALLOWED_MPI_STACKS)
+    message(FATAL_ERROR "MPI_STACK must be one of the following: ${ALLOWED_MPI_STACKS}")
+  else()
+    set(MPI_STACK_TYPE "User Specified")
+    message(WARNING "MPI_STACK is user specified. Please ensure that the specified MPI stack is compatible with the build. NOTE: MPI_STACK_VERSION is not being set.")
+  endif()
+else ()
+  message(STATUS "MPI_STACK not specified. Attempting to autodetect MPI stack...")
+  message(DEBUG "MPI_Fortran_LIBRARY_VERSION_STRING: ${MPI_Fortran_LIBRARY_VERSION_STRING}")
+
+  string(REPLACE " " ";" MPI_Fortran_LIBRARY_VERSION_LIST ${MPI_Fortran_LIBRARY_VERSION_STRING})
+  message(DEBUG "MPI_Fortran_LIBRARY_VERSION_LIST: ${MPI_Fortran_LIBRARY_VERSION_LIST}")
+  list(GET MPI_Fortran_LIBRARY_VERSION_LIST 0 MPI_Fortran_LIBRARY_VERSION_FIRSTWORD)
+  message(DEBUG "MPI_Fortran_LIBRARY_VERSION_FIRSTWORD: ${MPI_Fortran_LIBRARY_VERSION_FIRSTWORD}")
+
+  if(MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel")
+    set(MPI_STACK intelmpi)
+    list(GET MPI_Fortran_LIBRARY_VERSION_LIST 3 MPI_STACK_VERSION)
+  elseif(MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "MVAPICH")
+    set(MPI_STACK mvapich)
+    # MVAPICH output for MPI_Fortran_LIBRARY_VERSION_STRING is complex and multi-line. 
+    # So we need to extract the first line from that multi-line string.
+    string(REGEX REPLACE "\n.*" "" MPI_Fortran_LIBRARY_VERSION_STRING_FIRST_LINE ${MPI_Fortran_LIBRARY_VERSION_STRING})
+    # Now we need to grab the last word from the first line of the string
+    string(REGEX MATCH "[^ ]+$" MPI_STACK_VERSION ${MPI_Fortran_LIBRARY_VERSION_STRING_FIRST_LINE})
+    # Now we need to remove any colons, spaces, tabs, etc., but keep dots and letters.
+    string(REGEX REPLACE "[^a-zA-Z0-9.]" "" MPI_STACK_VERSION ${MPI_STACK_VERSION})
+  elseif(MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "MPT")
+    set(MPI_STACK mpt)
+    list(GET MPI_Fortran_LIBRARY_VERSION_LIST 2 MPI_STACK_VERSION)
+  elseif(MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "MPICH")
+    set(MPI_STACK mpich)
+    # MPICH output for MPI_Fortran_LIBRARY_VERSION_STRING is complex and multi-line. 
+    # So we need to extract the first line from that multi-line string.
+    string(REGEX REPLACE "\n.*" "" MPI_Fortran_LIBRARY_VERSION_STRING_FIRST_LINE ${MPI_Fortran_LIBRARY_VERSION_STRING})
+    # Now we need to grab the last word from the first line of the string
+    string(REGEX MATCH "[^ ]+$" MPI_STACK_VERSION ${MPI_Fortran_LIBRARY_VERSION_STRING_FIRST_LINE})
+    # Now we need to remove any colons, spaces, tabs, etc., but keep dots and letters.
+    string(REGEX REPLACE "[^a-zA-Z0-9.]" "" MPI_STACK_VERSION ${MPI_STACK_VERSION})
+  elseif(MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Open MPI")
+    set(MPI_STACK openmpi)
+    list(GET MPI_Fortran_LIBRARY_VERSION_LIST 2 DETECTED_MPI_STACK_VERSION_STRING_WITH_COMMA)
+    string(REPLACE "," "" DETECTED_MPI_STACK_VERSION_STRING_WITH_V ${DETECTED_MPI_STACK_VERSION_STRING_WITH_COMMA})
+    string(REPLACE "v" "" MPI_STACK_VERSION        ${DETECTED_MPI_STACK_VERSION_STRING_WITH_V})
+  else()
+    message (FATAL_ERROR "ERROR: MPI_STACK autodetection failed. Must specify a value for MPI_STACK with cmake ... -DMPI_STACK=<mpistack>. The acceptable values are: intelmpi, mvapich, mpt, mpich, openmpi")
+  endif()
+  set(MPI_STACK_TYPE "Autodetected")
+endif()
+
+set(MPI_STACK "${MPI_STACK}" CACHE STRING "MPI_STACK Value")
+set(MPI_STACK_VERSION "${MPI_STACK_VERSION}" CACHE STRING "MPI_STACK_VERSION Value")
+message(STATUS "Using ${MPI_STACK_TYPE} MPI_STACK: ${MPI_STACK}. Version: ${MPI_STACK_VERSION}")


### PR DESCRIPTION
This PR uses CMake to determine the MPI stack for GEOS. It provides two new variables:

- `MPI_STACK`: The detected MPI stack. The possible variables set are:
  - `intelmpi`
  - `openmpi`
  - `mpt`
  - `mpich`
  - `mvapich`

A user can also override this with `-DMPI_STACK=openmpi` say and the whole autodetection will be skipped.

- `MPI_STACK_VERSION`
  - NOTE: This is not the version of MPI standard the stack supports, but the version of the stack itself.
    For the MPI Standard supported use `MPI_C_VERSION` and `MPI_Fortran_VERSION` provided by `FindMPI` module.
