### PR TITLE
Add support for Hygon with GCC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for Hygon processors with GCC
+
 ### Changed
 
 ### Deprecated

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -136,7 +136,7 @@ elseif (${proc_description} MATCHES "Hygon")
   # see https://github.com/geoschem/GCHP/issues/391
   # Intel was happy with AVX2, but this test was done with GCC 10
   # Perhaps later versions of GCC would return a different value?
-  # Until then, nocona is definitely save. Pentium 4!
+  # Until then, nocona is definitely safe. Pentium 4!
   set (GNU_TARGET_ARCH "nocona")
   set (GNU_NATIVE_ARCH "native")
   set (NO_FMA "-mno-fma")

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -131,6 +131,15 @@ elseif (${proc_description} MATCHES "EPYC")
   set (GNU_TARGET_ARCH "znver2")
   set (GNU_NATIVE_ARCH "native")
   set (NO_FMA "-mno-fma")
+elseif (${proc_description} MATCHES "Hygon")
+  # Tests on a Hygon showed it returned 'nocona' for the native arch
+  # see https://github.com/geoschem/GCHP/issues/391
+  # Intel was happy with AVX2, but this test was done with GCC 10
+  # Perhaps later versions of GCC would return a different value?
+  # Until then, nocona is definitely save. Pentium 4!
+  set (GNU_TARGET_ARCH "nocona")
+  set (GNU_NATIVE_ARCH "native")
+  set (NO_FMA "-mno-fma")
 elseif (${proc_description} MATCHES "Intel")
   set (GNU_TARGET_ARCH "haswell")
   set (GNU_NATIVE_ARCH "native")


### PR DESCRIPTION
Closes #360 

This PR adds support for Hygon processors with GCC. Tests by @TianYangMY in https://github.com/geoschem/GCHP/issues/391 showed that GCC 10 reported `nocona` as its arch. Seems a bit old (Pentium 4!) but should be safe. I'll keep this draft until testing has occurred.