### PR TITLE
Add quiet flag for NAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added `-quiet` flag for NAG compilation. This suppresses the compiler banner and the summary line, so that only diagnostic messages will appear.
+
 ### Deprecated
 
 ## [3.41.0] - 2024-02-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Added `-quiet` flag for NAG compilation. This suppresses the compiler banner and the summary line, so that only diagnostic messages will appear.
-
 ### Deprecated
+
+## [3.42.0] - 2024-03-08
+
+### Changed
+
+- Added `-quiet` flag for NAG compilation. This suppresses the compiler banner and the summary line, so that only diagnostic messages will appear.
 
 ## [3.41.0] - 2024-02-20
 

--- a/compiler/flags/NAG_Fortran.cmake
+++ b/compiler/flags/NAG_Fortran.cmake
@@ -14,6 +14,9 @@ set (FIXED_SOURCE "-fixed")
 set (SUPPRESS_UNUSED_DUMMY "-w=uda")
 set (F2018 "-f2018")
 set (OPENMP "-not_openmp")
+# Add quiet flag
+#        -quiet    Suppress the compiler banner and the summary line, so that only diagnostic messages will appear.
+set (QUIET "-quiet")
 
 if (APPLE)
   option (ESMF_HAS_ACHAR_BUG "ESMF Compatibility issue" OFF)
@@ -23,7 +26,7 @@ endif ()
 
 # Common Fortran Flags
 # --------------------
-set (common_Fortran_flags "${F2018} ${MISMATCH} ${OPENMP}")
+set (common_Fortran_flags "${F2018} ${MISMATCH} ${OPENMP} ${QUIET}")
 set (common_Fortran_fpe_flags "")
 
 # GEOS Debug


### PR DESCRIPTION
This adds the `-quiet` flag for NAG:
```
        -quiet    Suppress the compiler banner and the summary line, so that only diagnostic messages will appear.
```

So this:

```
❯ mpifort -o helloWorld.mpi3.exe helloWorld.mpi3.F90
NAG Fortran Compiler Release 7.1(Hanzomon) Build 7143
[NAG Fortran Compiler normal termination]
```
becomes:
```
❯ mpifort -quiet -o helloWorld.mpi3.exe helloWorld.mpi3.F90
```

which is nice.