### PR TITLE
Fix Intel Debug flags for Intel ifort 2021.10+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove passing in `-init=snan,arrays` and `-fpe0` for Debug flags with Intel Fortran Classic `ifort` 2021.10 or higher. This
+  prevents failures in running `nf90_create` within MAPL (and in standalone)
+
 ### Deprecated
 
 ## [3.42.0] - 2024-03-08

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -48,6 +48,7 @@ set (FMA "-fma")
 set (ALIGN_ALL "-align all")
 set (NO_ALIAS "-fno-alias")
 set (USE_SVML "-fimf-use-svml=true")
+set (INIT_SNAN "-init=snan,arrays")
 
 # Additional flags for better Standards compliance
 ## Set the Standard to be Fortran 2018
@@ -116,8 +117,35 @@ set (common_Fortran_fpe_flags "${FTZ} ${NOOLD_MAXMINLOC} ${DISABLE_10121}")
 
 # GEOS Debug
 # ----------
-set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check all,noarg_temp_created -fp-stack-check ${WARN_UNUSED} -init=snan,arrays -save-temps")
-set (GEOS_Fortran_Debug_FPE_Flags "${FPE0} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${FP_MODEL_EXCEPT} ${common_Fortran_fpe_flags} ${SUPPRESS_COMMON_WARNINGS}")
+set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check all,noarg_temp_created -fp-stack-check ${WARN_UNUSED} -save-temps")
+
+# Testing shows that -init=snan,arrays and -fpe0 causes MAPL test failures with
+# Intel Fortran 2021.10. So we will append the flags only if the version
+# is less than 2021.10. However, we have to check the version in a weird
+# way. For example, Intel ifort 2021.6 is reported by CMake as:
+#   2021.6.0.20220226
+# Intel 2021.10 reports as:
+#   2021.10.0.20230609
+# but Intel ifort 2021.11 is reported by CMake as:
+#   2021.0.0.20231010
+# So we can't depend on anything but the last node of the version string.
+# First we need to extract the last node of the version string
+string(REGEX MATCH "([0-9]+)$" CMAKE_Fortran_COMPILER_VERSION_LAST_NODE ${CMAKE_Fortran_COMPILER_VERSION})
+message(STATUS "CMAKE_Fortran_COMPILER_VERSION_LAST_NODE: ${CMAKE_Fortran_COMPILER_VERSION_LAST_NODE}")
+
+# Now we can compare the last node to see if it is less than 20230609
+if (CMAKE_Fortran_COMPILER_VERSION_LAST_NODE VERSION_LESS 20230609)
+  message(STATUS "Adding -init=snan,arrays to GEOS_Fortran_Debug_Flags")
+  set (GEOS_Fortran_Debug_Flags "${GEOS_Fortran_Debug_Flags} ${INIT_SNAN}")
+endif ()
+
+set (GEOS_Fortran_Debug_FPE_Flags "${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${FP_MODEL_EXCEPT} ${common_Fortran_fpe_flags} ${SUPPRESS_COMMON_WARNINGS}")
+
+# Like above, we can only add ${FPE0} if the version is less than 20230609
+if (CMAKE_Fortran_COMPILER_VERSION_LAST_NODE VERSION_LESS 20230609)
+  message(STATUS "Adding ${FPE0} to GEOS_Fortran_Debug_FPE_Flags")
+  set (GEOS_Fortran_Debug_FPE_Flags "${GEOS_Fortran_Debug_FPE_Flags} ${FPE0}")
+endif ()
 
 # GEOS NoVectorize
 # ----------------

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -131,11 +131,9 @@ set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} -debug -nolib-inline -fno-inl
 # So we can't depend on anything but the last node of the version string.
 # First we need to extract the last node of the version string
 string(REGEX MATCH "([0-9]+)$" CMAKE_Fortran_COMPILER_VERSION_LAST_NODE ${CMAKE_Fortran_COMPILER_VERSION})
-message(STATUS "CMAKE_Fortran_COMPILER_VERSION_LAST_NODE: ${CMAKE_Fortran_COMPILER_VERSION_LAST_NODE}")
 
 # Now we can compare the last node to see if it is less than 20230609
 if (CMAKE_Fortran_COMPILER_VERSION_LAST_NODE VERSION_LESS 20230609)
-  message(STATUS "Adding -init=snan,arrays to GEOS_Fortran_Debug_Flags")
   set (GEOS_Fortran_Debug_Flags "${GEOS_Fortran_Debug_Flags} ${INIT_SNAN}")
 endif ()
 
@@ -143,7 +141,6 @@ set (GEOS_Fortran_Debug_FPE_Flags "${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${F
 
 # Like above, we can only add ${FPE0} if the version is less than 20230609
 if (CMAKE_Fortran_COMPILER_VERSION_LAST_NODE VERSION_LESS 20230609)
-  message(STATUS "Adding ${FPE0} to GEOS_Fortran_Debug_FPE_Flags")
   set (GEOS_Fortran_Debug_FPE_Flags "${GEOS_Fortran_Debug_FPE_Flags} ${FPE0}")
 endif ()
 


### PR DESCRIPTION
Testing by @tclune found a weird failure in pfio unit tests in MAPL (see https://github.com/GEOS-ESM/MAPL/issues/2641). Further testing found the bug could be triggered in a standalong netCDF-Fortran code. 

Eventually, it was found that setting either `-init=snan,arrays` or `-fpe0` caused the `nf90_create` call to crash. 

This PR removes those flags if the `ifort` version is 2021.10 or higher.

NOTE: I have no idea if this is zero-diff or non-zero-diff. I'm not sure if `-fpe0` causes a change...