### PR TITLE
Workaround GCC + Open MPI 5 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Avoid bug with GCC and Open MPI 5 by not using `-ffpe-trap=zero` in flags
+
 ### Removed
 
 ### Added

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -110,6 +110,9 @@ set (NO_ALIAS "")
 
 set (NO_RANGE_CHECK "-fno-range-check")
 
+set (TRAP_ZERO "-ffpe-trap=zero")
+set (TRAP_OVERFLOW "-ffpe-trap=overflow")
+
 cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
 
 if ( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64 )
@@ -151,7 +154,7 @@ add_definitions(-D__GFORTRAN__)
 # Common Fortran Flags
 # --------------------
 set (common_Fortran_flags "-ffree-line-length-none ${NO_RANGE_CHECK} -Wno-missing-include-dirs ${TRACEBACK} ${UNUSED_DUMMY}" )
-set (common_Fortran_fpe_flags "-ffpe-trap=zero,overflow ${TRACEBACK} ${MISMATCH} ${ALLOW_BOZ}")
+set (common_Fortran_fpe_flags "${TRAP_ZERO} ${TRAP_OVERFLOW} ${TRACEBACK} ${MISMATCH} ${ALLOW_BOZ}")
 
 # GEOS Debug
 # ----------


### PR DESCRIPTION
This is an *ugly* hack to work around a bug between GCC and Open MPI 5. Tests determined that on discover (at least) running GEOSgcm with `-ffpe-trap=zero` caused a crash on `MPI_Init`. This was reported to Open MPI in https://github.com/open-mpi/ompi/issues/12400

For now, the workaround is if GCC 13 + Open MPI 5.

The other problem is it's discover specific, which isn't great. 

I'm going to keep this in draft for now so I don't lose it, but hopefully the ompi folks can help me out.