### PR TITLE
Run essential tests with make tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change `make tests` to only do tests labeled with `ESSENTIAL`. Add new `make tests-all` to run all tests.
-
 ### Deprecated
+
+## [3.43.0] - 2024-03-18
+
+### Changed
+
+- Change `make tests` to only do tests labeled with `ESSENTIAL`. Add new `make tests-all` to run all tests.
 
 ## [3.42.0] - 2024-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change `make tests` to only do tests labeled with `ESSENTIAL`. Add new `make tests-all` to run all tests.
+
 ### Deprecated
 
 ## [3.42.0] - 2024-03-08

--- a/esma_support/esma_enable_tests.cmake
+++ b/esma_support/esma_enable_tests.cmake
@@ -3,9 +3,14 @@ find_package(PFUNIT QUIET)
 
 add_custom_target(build-tests)
 add_custom_target(tests
-  COMMAND ${CMAKE_CTEST_COMMAND}
+  COMMAND ${CMAKE_CTEST_COMMAND} -L 'ESSENTIAL' --output-on-failure
   EXCLUDE_FROM_ALL)
 add_dependencies(tests build-tests)
+
+add_custom_target(tests-all
+  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+  EXCLUDE_FROM_ALL)
+add_dependencies(tests-all build-tests)
 
 # The following forces tests to be built when using "make ctest" even if some targets
 # are EXCLUDE_FROM_ALL


### PR DESCRIPTION
This PR changes the usual `make tests` command we often use in GEOS to run only those tests labeled with `ESSENTIAL`. To run all tests, use `make tests-all`.

This will require a PR in MAPL as well to "work" in that, if you have ESMA_cmake v3.43 but not the concomitant PR in MAPL, you'll run...nothing since nothing will have the `ESSENTIAL` label.