### PR TITLE
Suppress ifort deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add suppression of remark 10488 for Intel Fortran Classic which is a warning about ifort deprecation in late 2024
+
 ### Changed
 
 ### Deprecated

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -65,6 +65,9 @@ set (DISABLE_10337 "-diag-disable 10337")
 ## Turn off ifort: command line warning #10121: overriding '-fp-model precise' with '-fp-model fast'
 set (DISABLE_10121 "-diag-disable 10121")
 
+## Turn off remark #10448 warning about ifort deprecation in late 2024
+set (DISABLE_10448 "-diag-disable=10448")
+
 set (NO_RANGE_CHECK "")
 
 cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
@@ -112,7 +115,7 @@ endif ()
 # Common Fortran Flags
 # --------------------
 set (common_Fortran_flags "${TRACEBACK} ${REALLOC_LHS} ${OPTREPORT0} ${ALIGN_ALL} ${NO_ALIAS}")
-set (common_Fortran_fpe_flags "${FTZ} ${NOOLD_MAXMINLOC} ${DISABLE_10121}")
+set (common_Fortran_fpe_flags "${FTZ} ${NOOLD_MAXMINLOC} ${DISABLE_10121} ${DISABLE_10448}")
 
 # GEOS Debug
 # ----------


### PR DESCRIPTION
This PR suppresses the:
```
ifort: remark #10448: Intel(R) Fortran Compiler Classic (ifort) is now deprecated and will be discontinued late 2024. Intel recommends that customers transition now to using the LLVM-based Intel(R) Fortran Compiler (ifx) for continued Windows* and Linux* support, new language support, new language features, and optimizations. Use '-diag-disable=10448' to disable this message.
```
warning from ifort about ifort's deprecation. This happens with *every* call to ifort so it gets...annoying.