### PR TITLE
Fixes for Python 3.12, meson, and f2py (v3 branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [3.45.3] - 2024-06-06
+## [3.45.3] - 2024-06-11
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [3.45.3] - 2024-06-11
+## [3.45.3] - 2024-06-14
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix issue with use of `meson` and `f2py` with more complex codes
+  - NOTE: Requires a fix to `f2py` that is not yet released. You can see the change
+    in the `numpy` repo at https://github.com/numpy/numpy/pull/26659
+    This fix has been applied to GEOSpyD 2.44.0-0
 
 ## [3.45.2] - 2024-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.45.3] - 2024-06-06
+
+### Fixed
+
+- Fix issue with use of `meson` and `f2py` with more complex codes
+
 ## [3.45.2] - 2024-05-16
 
 ### Fixed

--- a/python/f2py3/UseF2Py3.cmake
+++ b/python/f2py3/UseF2Py3.cmake
@@ -85,7 +85,7 @@ macro (add_f2py3_module _name)
     set(F2PY3_BACKEND "distutils")
   endif ()
 
-  message(STATUS "Using F2PY3_BACKEND: ${F2PY3_BACKEND}")
+  #message(STATUS "Using F2PY3_BACKEND: ${F2PY3_BACKEND}")
 
   if (F2PY3_BACKEND STREQUAL "distutils")
     set(_fcompiler_opts "--fcompiler=${F2PY3_FCOMPILER}")
@@ -269,7 +269,7 @@ macro (add_f2py3_module _name)
       COMMAND ${CMAKE_COMMAND} -E env "FC=${CMAKE_Fortran_COMPILER}"
               ${F2PY3_EXECUTABLE} ${F2PY_QUIET} -m ${_name}
               --build-dir "${CMAKE_CURRENT_BINARY_DIR}/f2py3-${_name}"
-              ${_fcompiler_opts} ${_inc_opts} -c ${_abs_srcs} ${REDIRECT_TO_DEV_NULL}
+              ${_fcompiler_opts} ${_inc_opts} ${_lib_opts} -c ${_abs_srcs} ${REDIRECT_TO_DEV_NULL}
       DEPENDS ${add_f2py3_module_SOURCES}
       COMMENT "[F2PY3] Building Fortran to Python3 interface module ${_name}")
   else ()


### PR DESCRIPTION
This fixes an issue between f2py3 and meson and python 3.12 found by @patricia-nasa.

NOTE: Requires a fix to  f2py  that is not yet released. You can see the change in the `numpy`  repo at https://github.com/numpy/numpy/pull/26659

This fix has been applied to GEOSpyD 2.44.0-0 by hand my @JulesKouatchou and myself