### PR TITLE
v3: Move detection of MPI out of FindBaselibs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.48.0] - 2024-07-15
+
+### Changed
+
+- Move detection out of `FindBaselibs.cmake` for Spack purposes
+
 ## [3.47.0] - 2024-07-11
 
 ### Fixed

--- a/esma.cmake
+++ b/esma.cmake
@@ -39,7 +39,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 ### MPI Support ###
 
-# MPI is now found in FindBaselibs
+set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
+find_package(MPI)
 
 ### Threading ###
 

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -73,10 +73,6 @@ endif ()
 
 if (Baselibs_FOUND)
 
-  # For now require MPI with Baselibs
-  set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
-  find_package(MPI)
-
   link_directories (${BASEDIR}/lib)
 
   # Add path to GFE packages
@@ -284,10 +280,6 @@ else ()
   # These should be in each fixture
 
   ###########################################
-  # # For now require MPI with Baselibs     #
-  # set(MPI_DETERMINE_LIBRARY_VERSION TRUE) #
-  # find_package(MPI)                       #
-  #                                         #
   # find_package(NetCDF REQUIRED Fortran)   #
   # add_definitions(-DHAS_NETCDF4)          #
   # add_definitions(-DHAS_NETCDF3)          #


### PR DESCRIPTION
This moves the `find_package(MPI)` call out of `FindBaselibs` which is now a dumb thing to do for Spack work.

Indeed, I think this is this issue for the insanity I've had to add to the MAPL spack package. Apologies to @climbfuji, @AlexanderRichert-NOAA, and potentially @Hang-Lei-NOAA. 