### PR TITLE
v3: Add the SMOD word in the target submodule file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.49.0] - 2024-08-01
+
+### Changed
+
+- Edit the file `esma_add_fortran_submodules.cmake` to add the `SMOD` word to the target submodule file name.
+
+
 ## [3.48.0] - 2024-07-15
 
 ### Changed

--- a/esma_support/esma_add_fortran_submodules.cmake
+++ b/esma_support/esma_add_fortran_submodules.cmake
@@ -13,8 +13,8 @@ function(esma_add_fortran_submodules)
   foreach(file ${ARG_SOURCES})
 
     set(input ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_SUBDIRECTORY}/${file})
-    set(output ${CMAKE_CURRENT_BINARY_DIR}/${ARG_SUBDIRECTORY}_${file})
-    set(esma_internal "esma_internal_${ARG_SUBDIRECTORY}_${file}")
+    set(output ${CMAKE_CURRENT_BINARY_DIR}/${ARG_SUBDIRECTORY}_SMOD_${file})
+    set(esma_internal "esma_internal_${ARG_SUBDIRECTORY}_SMOD_${file}")
 
     add_custom_command(
       OUTPUT ${output}


### PR DESCRIPTION
Edited the file `esma_add_fortran_submodules.cmake` to add the `SMOD` word in the target submodule file name. Now the submodule file name (`file.F90`) will be renamed (for compilation purpose only) `moduleName_SMOD_file.F90` instead of `moduleName_file.F90`.

Based on #393 from @JulesKouatchou 