### PR TITLE
Workaround for OpenMP + NAG + CMake (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add workaround to support OpenMP linking with NAG under CMake
+
 ### Deprecated
 
 ## [3.49.0] - 2024-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add workaround to support OpenMP linking with NAG under CMake
-
 ### Deprecated
+
+## [3.50.0] - 2024-08-12
+
+### Changed
+
+- Add workaround to support OpenMP linking with NAG under CMake
 
 ## [3.49.0] - 2024-08-01
 

--- a/compiler/flags/NAG_Fortran.cmake
+++ b/compiler/flags/NAG_Fortran.cmake
@@ -13,7 +13,6 @@ set (EXTENDED_SOURCE "-132 -w=x95" )
 set (FIXED_SOURCE "-fixed")
 set (SUPPRESS_UNUSED_DUMMY "-w=uda")
 set (F2018 "-f2018")
-set (OPENMP "-not_openmp")
 # Add quiet flag
 #        -quiet    Suppress the compiler banner and the summary line, so that only diagnostic messages will appear.
 set (QUIET "-quiet")
@@ -26,7 +25,7 @@ endif ()
 
 # Common Fortran Flags
 # --------------------
-set (common_Fortran_flags "${F2018} ${MISMATCH} ${OPENMP} ${QUIET}")
+set (common_Fortran_flags "${F2018} ${MISMATCH} ${QUIET}")
 set (common_Fortran_fpe_flags "")
 
 # GEOS Debug

--- a/esma.cmake
+++ b/esma.cmake
@@ -33,6 +33,15 @@ include (esma_compiler)
 
 find_package (OpenMP)
 
+# CMake has a bug with NAG and OpenMP:
+#   https://gitlab.kitware.com/cmake/cmake/-/issues/21280
+# so we work around it
+if (OpenMP_Fortran_FOUND AND CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
+  message(STATUS "NAG Fortran detected, resetting OpenMP flags to avoid CMake bug")
+  set_property(TARGET OpenMP::OpenMP_Fortran PROPERTY INTERFACE_LINK_LIBRARIES "")
+  set_property(TARGET OpenMP::OpenMP_Fortran PROPERTY INTERFACE_LINK_OPTIONS "-openmp")
+endif()
+
 ### Position independent code ###
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
This adds a workaround for a bug between NAG, OpenMP, and CMake.

See https://gitlab.kitware.com/cmake/cmake/-/issues/21280 for more info.