### PR TITLE
v3: Support for MAPL-as-library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.52.0] - 2024-10-XX
+
+### Changed
+
+- Support for building GEOSgcm with Spack using MAPL as library
+  - Update `esma_create_stub_component` to look for `mapl_stub.pl` in `$MAPL_BASE_DIR/etc` which is a variable defined by ecbuild
+  - Make finding `mapl_stub.pl` required (needs CMake 3.18+)
+
 ## [3.51.0] - 2024-09-05
 
 ### Added

--- a/esma_support/esma_create_stub_component.cmake
+++ b/esma_support/esma_create_stub_component.cmake
@@ -1,9 +1,14 @@
+# find_file REQUIRED requires CMake 3.18
+cmake_minimum_required (VERSION 3.18)
+
 macro (esma_create_stub_component srcs module)
   list (APPEND ${srcs} ${module}.F90)
 
   find_file (stub_generator
     NAME mapl_stub.pl
-    PATHS ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL)
+    PATHS ${MAPL_BASE_DIR}/etc ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL
+    REQUIRED
+  )
 
   add_custom_command (
     OUTPUT ${module}.F90
@@ -11,7 +16,7 @@ macro (esma_create_stub_component srcs module)
     MAIN_DEPENDENCY ${stub_generator}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Making component stub for ${module}Mod in ${module}.F90"
-    )
+  )
   add_custom_target(stub_${module} DEPENDS ${module}.F90)
 
 endmacro ()


### PR DESCRIPTION
It has been requested by some of the spack-stack folks (e.g., @climbfuji) that GEOSgcm when built with Spack should be able to use MAPL as a library rather than as a component built in.

I believe this is all that is necessary. We just need to tell CMake where `mapl_stub.pl` is. Because MAPL is built under ecbuild, that means it has a variable called `MAPL_BASE_DIR`[^1] that points to where MAPL is, e.g., in spack, where spack installed it.

At the moment it seems to pass CMake. I'm exploring more.


[^1]: This is not great for MAPL since MAPL_Base is a thing for us, but, well, that's what ecbuild does.