### PR TITLE
v4: Support for MAPL-as-library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 #bcs_version: &bcs_version v11.3.0
 
 orbs:
-  ci: geos-esm/circleci-tools@3
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   build-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.7.0] - 2024-10-10
+
+- Support for building GEOSgcm with Spack using MAPL as library
+  - Update `esma_create_stub_component` to look for `mapl_stub.pl` in `$MAPL_BASE_DIR/etc` (which is a variable defined by ecbuild)
+  - Update `esma_generate_automatic_code` to look for `mapl_acg.pl` in `$MAPL_BASE_DIR/etc` (which is a variable defined by ecbuild)
+  - Require CMake 3.18 for features used in above updates
+- Update to CircleCI orb v4
+
 ## [4.6.0] - 2024-09-05
 
 ### Added

--- a/esma_support/esma_create_stub_component.cmake
+++ b/esma_support/esma_create_stub_component.cmake
@@ -1,9 +1,15 @@
+# find_file REQUIRED requires CMake 3.18
+cmake_minimum_required (VERSION 3.18)
+
 macro (esma_create_stub_component srcs module)
   list (APPEND ${srcs} ${module}.F90)
 
   find_file (stub_generator
     NAME mapl_stub.pl
-    PATHS ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL)
+    PATHS ${MAPL_BASE_DIR}/etc ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL
+    DOC "Path to MAPL stub generator"
+    REQUIRED
+  )
 
   add_custom_command (
     OUTPUT ${module}.F90
@@ -11,7 +17,7 @@ macro (esma_create_stub_component srcs module)
     MAIN_DEPENDENCY ${stub_generator}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Making component stub for ${module}Mod in ${module}.F90"
-    )
+  )
   add_custom_target(stub_${module} DEPENDS ${module}.F90)
 
 endmacro ()

--- a/esma_support/esma_generate_automatic_code.cmake
+++ b/esma_support/esma_generate_automatic_code.cmake
@@ -1,5 +1,7 @@
 # Generate headers and  resource files for GOCART components
 
+cmake_minimum_required (VERSION 3.18)
+
 set (acg_flags -v)
 
 macro (new_esma_generate_automatic_code
@@ -7,7 +9,9 @@ macro (new_esma_generate_automatic_code
 
   find_file (generator
     NAME mapl_acg.pl
-    PATHS ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL)
+    PATHS ${MAPL_BASE_DIR}/etc ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL
+    DOC "Path to the perl MAPL ACG generator"
+  )
 
   add_custom_command (
     OUTPUT ${rcs}
@@ -59,7 +63,9 @@ macro (esma_generate_gmi_code target type)
 
   find_file (generator
     NAME mapl_acg.pl
-    PATHS ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL)
+    PATHS ${MAPL_BASE_DIR}/etc ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL
+    DOC "Path to the perl MAPL ACG generator"
+  )
 
   add_custom_command (
     #    TARGET ${this}
@@ -85,7 +91,10 @@ macro (esma_generate_automatic_code this name destination flags)
 
   find_file (generator
     NAME mapl_acg.pl
-    PATHS ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL)
+    PATHS ${MAPL_BASE_DIR}/etc ${MAPL_SOURCE_DIR}/Apps ${esma_etc}/MAPL
+    DOC "Path to the perl MAPL ACG generator"
+    REQUIRED
+  )
 
   add_custom_command (
     OUTPUT ${name}_ExportSpec___.h ${name}_GetPointer___.h ${name}_History___.rc


### PR DESCRIPTION
It has been requested by some of the spack-stack folks (e.g., @climbfuji) that GEOSgcm when built with Spack should be able to use MAPL as a library rather than as a component built in.

I believe this is all that is necessary. We just need to tell CMake where `mapl_stub.pl` is. Because MAPL is built under ecbuild, that means it has a variable called `MAPL_BASE_DIR`[^1] that points to where MAPL is, e.g., in spack, where spack installed it.

[^1]: This is not great for MAPL since MAPL_Base is a thing for us, but, well, that's what ecbuild does.