### PR TITLE
v3: Add output of mepo status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.53.0] - 2024-11-05
+
+### Added
+
+- Added new `esma_capture_mepo_status` function (in `esma_support/esma_mepo_status.cmake`) to capture the output of `mepo status --hashes` when `mepo` was used to clone the fixture. It will output this into a file `MEPO_STATUS.rc` which is installed to `${CMAKE_INSTALL_PREFIX}/etc` and can be used to help determine the exact state of the fixture at build time.
+
 ## [3.52.0] - 2024-10-10
 
 ### Changed

--- a/esma.cmake
+++ b/esma.cmake
@@ -79,6 +79,9 @@ include(DetermineMPIStack)
 #list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/esma_support")
 include (esma_support)
 
+#### Capture mepo status ####
+esma_capture_mepo_status()
+
 ### Python ###
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/python")

--- a/esma_support/esma_mepo_status.cmake
+++ b/esma_support/esma_mepo_status.cmake
@@ -1,0 +1,43 @@
+function(esma_capture_mepo_status)
+
+  # Step 1: Set the path to the .mepo directory
+  set(MEPO_DIR "${CMAKE_SOURCE_DIR}/.mepo")
+  set(OUTPUT_FILE_NAME "MEPO_STATUS.rc")
+  set(OUTPUT_FILE "${CMAKE_BINARY_DIR}/${OUTPUT_FILE_NAME}")
+
+  if(EXISTS "${MEPO_DIR}")
+    message(DEBUG ".mepo directory found")
+
+    # Step 2: Check for the `mepo` command
+    find_program(MEPO_COMMAND mepo)
+
+    if(MEPO_COMMAND)
+      message(DEBUG "Found mepo command at ${MEPO_COMMAND}")
+
+      # Step 3: Run `mepo status --hashes` and capture the output
+      execute_process(
+        COMMAND ${MEPO_COMMAND} status --hashes
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_FILE "${OUTPUT_FILE}"
+        RESULT_VARIABLE MEPO_STATUS_RESULT
+      )
+
+      if(NOT MEPO_STATUS_RESULT EQUAL 0)
+        message(WARNING "mepo state and command were found but failed to run mepo status --hashes. This is odd.")
+      else()
+        message(STATUS "mepo status output captured in ${OUTPUT_FILE_NAME}")
+
+        # Step 4: Install the output file in the etc directory
+        install(
+          FILES "${OUTPUT_FILE}"
+          DESTINATION etc
+          )
+      endif()
+    else()
+      message(DEBUG "mepo command not found, skipping mepo status")
+    endif()
+  else()
+    message(DEBUG ".mepo directory not found, skipping mepo status check")
+  endif()
+
+endfunction()

--- a/esma_support/esma_support.cmake
+++ b/esma_support/esma_support.cmake
@@ -9,6 +9,7 @@ include (esma_generate_automatic_code)
 include (esma_create_stub_component)
 include (esma_fortran_generator_list)
 include (esma_add_fortran_submodules)
+include (esma_mepo_status)
 
 # Testing
 include (esma_enable_tests)


### PR DESCRIPTION
This PR adds a new `esma_capture_mepo_status` function (in `esma_support/esma_mepo_status.cmake`) to capture the output of `mepo status --hashes` when `mepo` was used to clone the fixture. It will output this into a file `MEPO_STATUS.rc` which is installed to `${CMAKE_INSTALL_PREFIX}/etc` and can be used to help determine the exact state of the fixture at build time.

This was suggested/inspired by @viral211 