### PR TITLE
v3: Do not determine MPI stack without MPI found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.53.1] - 2024-11-07
+
+### Fixed
+
+- Do not include `DetermineMPIStack` if MPI is not found
+
 ## [3.53.0] - 2024-11-05
 
 ### Added

--- a/esma.cmake
+++ b/esma.cmake
@@ -72,7 +72,9 @@ include(math_libraries)
 include(FindBaselibs)
 include(DetermineSite)
 find_package(GitInfo)
-include(DetermineMPIStack)
+if (MPI_FOUND)
+  include(DetermineMPIStack)
+endif ()
 
 ### ESMA Support ###
 


### PR DESCRIPTION
There are cases where we do not require MPI. In such cases, we cannot run the `DetermineMPIStack` code.