### PR TITLE
v4: Use LOCATION Python FIND_STRATEGY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+[4.11.0] - 2025-01-03
+
+### Changed
+
+- Move to use Python `FIND_STRATEGY LOCATION` by default. This is needed as NAS (at least) has a very recent, but empty (no f2py) Python stack in the default path. Using `LOCATION` should limit it to the Python we want (e.g., via GEOSpyD module)
+
 ## [4.10.0] - 2024-12-02
 
 ### Fixed

--- a/python/esma_find_python3_module.cmake
+++ b/python/esma_find_python3_module.cmake
@@ -5,7 +5,6 @@
 # Citation: https://cmake.org/pipermail/cmake/2011-January/041666.html
 # Mark Moll
 
-set(Python3_FIND_STRATEGY VERSION)
 find_package(Python3 COMPONENTS Interpreter)
 
 function(esma_find_python3_module module)

--- a/python/esma_python.cmake
+++ b/python/esma_python.cmake
@@ -5,10 +5,11 @@
 cmake_minimum_required(VERSION 3.24)
 
 # Find Python
+set(Python_FIND_STRATEGY LOCATION)
 find_package(Python COMPONENTS Interpreter)
 
 # Find Python2
-set(Python2_FIND_STRATEGY VERSION)
+set(Python2_FIND_STRATEGY LOCATION)
 find_package(Python2 COMPONENTS Interpreter)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/f2py2")
 include (esma_find_python2_module)
@@ -16,7 +17,7 @@ include (esma_check_python2_module)
 include (esma_add_f2py2_module)
 
 # Find Python3
-set(Python3_FIND_STRATEGY VERSION)
+set(Python3_FIND_STRATEGY LOCATION)
 find_package(Python3 COMPONENTS Interpreter)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/f2py3")
 include (esma_find_python3_module)


### PR DESCRIPTION
Tests at NAS have shown that using the `VERSION` find strategy for Python was causing an issue because there is a `/usr/bin/python3.12` that is on the system `PATH` but it is "basic" and doesn't have `f2py` so our `f2py` bits were failing. 

Using `LOCATION` tells it to use the Python we want (e.g., GEOSpyD)