### PR TITLE
v3: Update ifx flags for avx2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update Intel LLVM Fortran flags to use `-march=x86-64-v3` as `-march=core-avx2` is not (technically?) supported by `ifx`
+
 ### Deprecated
 
 ## [3.56.0] - 2025-01-03

--- a/compiler/flags/IntelLLVM_Fortran.cmake
+++ b/compiler/flags/IntelLLVM_Fortran.cmake
@@ -63,23 +63,18 @@ set (NO_RANGE_CHECK "")
 
 cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
 if (${proc_description} MATCHES "EPYC")
-  # AMD EPYC processors support AVX2, but only via the -march=core-avx2 flag
-  set (COREAVX2_FLAG "-march=core-avx2")
+  set (MARCH_FLAG "-march=x86-64-v3")
 elseif (${proc_description} MATCHES "Hygon")
-  # Hygon processors support AVX2, but only via the -march=core-avx2 flag
-  set (COREAVX2_FLAG "-march=core-avx2")
+  set (MARCH_FLAG "-march=x86-64-v3")
 elseif (${proc_description} MATCHES "Intel")
   # All the Intel processors that GEOS runs on support AVX2, but to be
-  # consistent with the AMD processors, we use the -march=core-avx2 flag
-  set (COREAVX2_FLAG "-march=core-avx2")
-  # Previous versions of GEOS used this flag, which was not portable
-  # for AMD. Keeping here for a few versions for historical purposes.
-  #set (COREAVX2_FLAG "-xCORE-AVX2")
+  # consistent with the AMD processors, we use the -march=x86-64-v3 flag
+  set (MARCH_FLAG "-march=x86-64-v3")
 elseif ( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64" )
   # This is a fallback for when the above doesn't work. It should work
   # for most x86_64 processors, but it is not guaranteed to be optimal.
   message(WARNING "Unknown processory type. Defaulting to a generic x86_64 processor. Performance may be suboptimal.")
-  set (COREAVX2_FLAG "")
+  set (MARCH_FLAG "x86-64")
 else ()
   message(FATAL_ERROR "Unknown processor. Please file an issue at https://github.com/GEOS-ESM/ESMA_cmake")
 endif ()
@@ -108,7 +103,7 @@ set (GEOS_Fortran_NoVect_FPE_Flags "${common_Fortran_fpe_flags} ${ARCH_CONSISTEN
 
 # GEOS Vectorize
 # --------------
-set (GEOS_Fortran_Vect_Flags "${FOPT3} ${DEBINFO} ${COREAVX2_FLAG} -fma -qopt-report0 ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -align array32byte")
+set (GEOS_Fortran_Vect_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -fma -qopt-report0 ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -align array32byte")
 set (GEOS_Fortran_Vect_FPE_Flags "${FPE3} ${FP_MODEL_CONSISTENT} ${NOOLD_MAXMINLOC}")
 
 # GEOS Release
@@ -118,7 +113,7 @@ set (GEOS_Fortran_Release_FPE_Flags "${GEOS_Fortran_Vect_FPE_Flags}")
 
 # GEOS Aggressive
 # ---------------
-set (GEOS_Fortran_Aggressive_Flags "${FOPT3} ${DEBINFO} ${COREAVX2_FLAG} -fma -qopt-report0 ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -align array32byte")
+set (GEOS_Fortran_Aggressive_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -fma -qopt-report0 ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -align array32byte")
 #set (GEOS_Fortran_Aggressive_Flags "${FOPT3} ${DEBINFO} -xSKYLAKE-AVX512 -qopt-zmm-usage=high -fma -qopt-report0 ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -align array64byte")
 set (GEOS_Fortran_Aggressive_FPE_Flags "${FPE3} ${FP_MODEL_FAST2} ${USE_SVML} ${NOOLD_MAXMINLOC}")
 


### PR DESCRIPTION
This pull request updates the Intel LLVM Fortran flags to use `-march=x86-64-v3` instead of `-march=core-avx2` across various configurations. This change ensures better compatibility and performance consistency across different processor types.

### Changes to compiler flags:

* [`compiler/flags/IntelLLVM_Fortran.cmake`](diffhunk://#diff-a7f6a702d45622d2a2a32bbc05824ad0e356eb6173e34e7061df7ef43d8388feL66-R77): Replaced `-march=core-avx2` with `-march=x86-64-v3` for AMD EPYC, Hygon, and Intel processors. Updated fallback flag for unknown processor types to `-march=x86-64`.
* [`compiler/flags/IntelLLVM_Fortran.cmake`](diffhunk://#diff-a7f6a702d45622d2a2a32bbc05824ad0e356eb6173e34e7061df7ef43d8388feL111-R106): Updated `GEOS_Fortran_Vect_Flags` to use `MARCH_FLAG` instead of `COREAVX2_FLAG`.
* [`compiler/flags/IntelLLVM_Fortran.cmake`](diffhunk://#diff-a7f6a702d45622d2a2a32bbc05824ad0e356eb6173e34e7061df7ef43d8388feL121-R116): Updated `GEOS_Fortran_Aggressive_Flags` to use `MARCH_FLAG` instead of `COREAVX2_FLAG`.

### Documentation update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR18-R19): Added a note about updating Intel LLVM Fortran flags to use `-march=x86-64-v3`.