### PR TITLE
v4: Fixes to allow for odd Python setups and f2py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change f2py detection for the odd case where there might be multiple Python installations. For now, if the path to the Python executable does not match the path to the f2py executable, we issue a `WARNING`. We use a `WARNING` since some installations (e.g., Spack) will have the Python executable in a different location than the f2py executable.
+- Removed warning that Baselibs is not supported, to a STATUS message.
+
 ### Deprecated
 
 ## [4.12.0] - 2025-02-11

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -59,12 +59,7 @@ if (BASEDIR)
   endif ()
   set (BASEDIR "${BASEDIR}" CACHE PATH "Path to installed baselibs" FORCE)
 else ()
-  ecbuild_warn(
-    "BASEDIR not specified.\n"
-    "If you wish to use Baselibs, please use:\n"
-    "   cmake ... -DBASEDIR=<path-to-Baselibs>\n"
-    "or set BASEDIR in your environment.\n\n"
-    "Note that building GEOS-ESM code without Baselibs is unsupported.")
+  message(STATUS "BASEDIR not set. Baselibs not found. Assume we are using Spack or other methods to provide dependencies")
 endif ()
 
 if (ESMA_SDF)

--- a/python/esma_python.cmake
+++ b/python/esma_python.cmake
@@ -6,10 +6,14 @@ cmake_minimum_required(VERSION 3.24)
 
 # Find Python
 set(Python_FIND_STRATEGY LOCATION)
+set(Python_FIND_UNVERSIONED_NAMES FIRST)
+set(Python_FIND_FRAMEWORK LAST)
 find_package(Python COMPONENTS Interpreter)
 
 # Find Python2
 set(Python2_FIND_STRATEGY LOCATION)
+set(Python2_FIND_UNVERSIONED_NAMES FIRST)
+set(Python2_FIND_FRAMEWORK LAST)
 find_package(Python2 COMPONENTS Interpreter)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/f2py2")
 include (esma_find_python2_module)
@@ -18,6 +22,8 @@ include (esma_add_f2py2_module)
 
 # Find Python3
 set(Python3_FIND_STRATEGY LOCATION)
+set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+set(Python3_FIND_FRAMEWORK LAST)
 find_package(Python3 COMPONENTS Interpreter)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/f2py3")
 include (esma_find_python3_module)

--- a/python/f2py/FindF2PY.cmake
+++ b/python/f2py/FindF2PY.cmake
@@ -31,11 +31,38 @@
 #
 
 # Path to the f2py executable
-find_program(F2PY_EXECUTABLE NAMES "f2py${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"
-                                   "f2py-${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"
-                                   "f2py${Python_VERSION_MAJOR}"
-                                   "f2py"
-                                   )
+
+## We might have an odd circumstance where there are a couple f2py around. As such,
+## we need to find the one that matches the Python_EXECUTABLE. This is a bit of a
+## hack, but it should work for most cases.
+
+## Find the directory where the Python_EXECUTABLE is located
+message(DEBUG "[F2PY]: Searching for f2py executable associated with Python_EXECUTABLE: ${Python_EXECUTABLE}")
+get_filename_component(PYTHON_EXECUTABLE_DIR ${Python_EXECUTABLE} DIRECTORY)
+message(DEBUG "[F2PY]: Python executable directory: ${PYTHON_EXECUTABLE_DIR}")
+
+find_program(F2PY_EXECUTABLE
+  NAMES "f2py"
+        "f2py${Python_VERSION_MAJOR}"
+        "f2py${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"
+        "f2py-${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"
+  PATHS ${PYTHON_EXECUTABLE_DIR}
+)
+
+message(DEBUG "[F2PY]: Found f2py executable: ${F2PY_EXECUTABLE}")
+
+# Now as a sanity check, we need to make sure that the f2py executable is
+# actually the one that is associated with the Python_EXECUTABLE
+get_filename_component(F2PY_EXECUTABLE_DIR ${F2PY_EXECUTABLE} DIRECTORY)
+message(DEBUG "[F2PY]: f2py executable directory: ${F2PY_EXECUTABLE_DIR}")
+
+# Now we issue a WARNING. We can't do more than that because of things like Spack
+# where f2py will be in a different location than python.
+if (NOT "${F2PY_EXECUTABLE_DIR}" STREQUAL "${PYTHON_EXECUTABLE_DIR}")
+  message(WARNING
+    "[F2PY]: The f2py executable [${F2PY_EXECUTABLE}] found is not the one associated with the Python_EXECUTABLE [${Python_EXECUTABLE}].\n"
+    "Please check your Python environment if this is not expected (for example, not a Spack install) or build with -DUSE_F2PY=OFF.")
+endif ()
 
 if(F2PY_EXECUTABLE)
    # extract the version string

--- a/python/f2py/try_f2py_compile.cmake
+++ b/python/f2py/try_f2py_compile.cmake
@@ -19,8 +19,22 @@ macro (try_f2py_compile file var)
    else ()
      set(MESON_F2PY_FCOMPILER "${CMAKE_Fortran_COMPILER}")
    endif ()
+   message(DEBUG "MESON_F2PY_FCOMPILER is set to ${MESON_F2PY_FCOMPILER}")
+   message(DEBUG "F2PY_COMPILER is set to ${F2PY_COMPILER}")
+   # hack for Macs. If the C compiler is clang and we are on Apple,
+   # we need to set the CC environment to /usr/bin/clang
+   if(APPLE AND CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+     set(MESON_CCOMPILER "/usr/bin/clang")
+     message(STATUS "Detected AppleClang on macOS. Using ugly hack for meson by passing in CC=/usr/bin/clang")
+   else()
+     set(MESON_CCOMPILER "${CMAKE_C_COMPILER}")
+   endif()
+   message(DEBUG "MESON_CCOMPILER is set to ${MESON_CCOMPILER}")
+   list(APPEND ENV_LIST FC=${MESON_F2PY_FCOMPILER})
+   list(APPEND ENV_LIST CC=${MESON_CCOMPILER})
+   message(DEBUG "ENV_LIST is set to ${ENV_LIST}")
    execute_process(
-     COMMAND cmake -E env "FC=${MESON_F2PY_COMPILER}" ${F2PY_EXECUTABLE} -m test_ -c ${file} --fcompiler=${F2PY_FCOMPILER}
+     COMMAND cmake -E env ${ENV_LIST} ${F2PY_EXECUTABLE} -m test_ -c ${file} --fcompiler=${F2PY_FCOMPILER}
      WORKING_DIRECTORY ${_f2py_check_bindir}
      RESULT_VARIABLE result
      OUTPUT_QUIET

--- a/python/f2py2/FindF2PY2.cmake
+++ b/python/f2py2/FindF2PY2.cmake
@@ -45,12 +45,37 @@ if(NOT Python2_FOUND)
   return()
 endif()
 
-# Path to the f2py2 executable
-find_program(F2PY2_EXECUTABLE NAMES "f2py${Python2_VERSION_MAJOR}.${Python2_VERSION_MINOR}"
-                                    "f2py-${Python2_VERSION_MAJOR}.${Python2_VERSION_MINOR}"
-                                    "f2py${Python2_VERSION_MAJOR}"
-                                    "f2py"
-                                    )
+## We might have an odd circumstance where there are a couple f2py around. As such,
+## we need to find the one that matches the Python2_EXECUTABLE. This is a bit of a
+## hack, but it should work for most cases.
+
+## Find the directory where the Python2_EXECUTABLE is located
+message(DEBUG "[F2PY2]: Searching for f2py2 executable associated with Python2_EXECUTABLE: ${Python2_EXECUTABLE}")
+get_filename_component(PYTHON2_EXECUTABLE_DIR ${Python2_EXECUTABLE} DIRECTORY)
+message(DEBUG "[F2PY2]: Python2 executable directory: ${PYTHON2_EXECUTABLE_DIR}")
+
+find_program(F2PY2_EXECUTABLE
+  NAMES "f2py"
+        "f2py${Python2_VERSION_MAJOR}"
+        "f2py${Python2_VERSION_MAJOR}.${Python2_VERSION_MINOR}"
+        "f2py-${Python2_VERSION_MAJOR}.${Python2_VERSION_MINOR}"
+  PATHS ${PYTHON2_EXECUTABLE_DIR}
+)
+
+message(DEBUG "[F2PY2]: Found f2py2 executable: ${F2PY2_EXECUTABLE}")
+
+# Now as a sanity check, we need to make sure that the f2py2 executable is
+# actually the one that is associated with the Python2_EXECUTABLE
+get_filename_component(F2PY2_EXECUTABLE_DIR ${F2PY2_EXECUTABLE} DIRECTORY)
+message(DEBUG "[F2PY2]: f2py2 executable directory: ${F2PY2_EXECUTABLE_DIR}")
+
+# Now we issue a WARNING. We can't do more than that because of things like Spack
+# where f2py will be in a different location than python.
+if (NOT "${F2PY2_EXECUTABLE_DIR}" STREQUAL "${PYTHON2_EXECUTABLE_DIR}")
+  message(WARNING
+    "[F2PY2]: The f2py2 executable [${F2PY2_EXECUTABLE}] found is not the one associated with the Python2_EXECUTABLE [${Python2_EXECUTABLE}].\n"
+    "Please check your Python2 environment if this is not expected (for example, not a Spack install) or build with -DUSE_F2PY=OFF.")
+endif ()
 
 if(F2PY2_EXECUTABLE)
    # extract the version string

--- a/python/f2py3/FindF2PY3.cmake
+++ b/python/f2py3/FindF2PY3.cmake
@@ -31,11 +31,38 @@
 #
 
 # Path to the f2py3 executable
-find_program(F2PY3_EXECUTABLE NAMES "f2py${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
-                                    "f2py-${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
-                                    "f2py${Python3_VERSION_MAJOR}"
-                                    "f2py"
-                                    )
+
+## We might have an odd circumstance where there are a couple f2py around. As such,
+## we need to find the one that matches the Python3_EXECUTABLE. This is a bit of a
+## hack, but it should work for most cases.
+
+## Find the directory where the Python3_EXECUTABLE is located
+message(DEBUG "[F2PY3]: Searching for f2py3 executable associated with Python3_EXECUTABLE: ${Python3_EXECUTABLE}")
+get_filename_component(PYTHON3_EXECUTABLE_DIR ${Python3_EXECUTABLE} DIRECTORY)
+message(DEBUG "[F2PY3]: Python3 executable directory: ${PYTHON3_EXECUTABLE_DIR}")
+
+find_program(F2PY3_EXECUTABLE
+  NAMES "f2py"
+        "f2py${Python3_VERSION_MAJOR}"
+        "f2py${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
+        "f2py-${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
+  PATHS ${PYTHON3_EXECUTABLE_DIR}
+)
+
+message(DEBUG "[F2PY3]: Found f2py3 executable: ${F2PY3_EXECUTABLE}")
+
+# Now as a sanity check, we need to make sure that the f2py3 executable is
+# actually the one that is associated with the Python3_EXECUTABLE
+get_filename_component(F2PY3_EXECUTABLE_DIR ${F2PY3_EXECUTABLE} DIRECTORY)
+message(DEBUG "[F2PY3]: f2py3 executable directory: ${F2PY3_EXECUTABLE_DIR}")
+
+# Now we issue a WARNING. We can't do more than that because of things like Spack
+# where f2py will be in a different location than python.
+if (NOT "${F2PY3_EXECUTABLE_DIR}" STREQUAL "${PYTHON3_EXECUTABLE_DIR}")
+  message(WARNING
+    "[F2PY3]: The f2py3 executable [${F2PY3_EXECUTABLE}] found is not the one associated with the Python3_EXECUTABLE [${Python3_EXECUTABLE}].\n"
+    "Please check your Python3 environment if this is not expected (for example, not a Spack install) or build with -DUSE_F2PY=OFF.")
+endif ()
 
 if(F2PY3_EXECUTABLE)
    # extract the version string

--- a/python/f2py3/try_f2py3_compile.cmake
+++ b/python/f2py3/try_f2py3_compile.cmake
@@ -19,8 +19,22 @@ macro (try_f2py3_compile file var)
    else ()
      set(MESON_F2PY3_FCOMPILER "${CMAKE_Fortran_COMPILER}")
    endif ()
+   message(DEBUG "MESON_F2PY3_FCOMPILER is set to ${MESON_F2PY3_FCOMPILER}")
+   message(DEBUG "F2PY3_COMPILER is set to ${F2PY3_COMPILER}")
+   # hack for Macs. If the C compiler is clang and we are on Apple,
+   # we need to set the CC environment to /usr/bin/clang
+   if(APPLE AND CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+     set(MESON_CCOMPILER "/usr/bin/clang")
+     message(STATUS "Detected AppleClang on macOS. Using ugly hack for meson by passing in CC=/usr/bin/clang")
+   else()
+     set(MESON_CCOMPILER "${CMAKE_C_COMPILER}")
+   endif()
+   message(DEBUG "MESON_CCOMPILER is set to ${MESON_CCOMPILER}")
+   list(APPEND ENV_LIST FC=${MESON_F2PY3_FCOMPILER})
+   list(APPEND ENV_LIST CC=${MESON_CCOMPILER})
+   message(DEBUG "ENV_LIST is set to ${ENV_LIST}")
    execute_process(
-     COMMAND cmake -E env "FC=${MESON_F2PY3_COMPILER}" ${F2PY3_EXECUTABLE} -m test_ -c ${file} --fcompiler=${F2PY3_FCOMPILER}
+     COMMAND cmake -E env ${ENV_LIST} ${F2PY3_EXECUTABLE} -m test_ -c ${file} --fcompiler=${F2PY3_FCOMPILER}
      WORKING_DIRECTORY ${_f2py3_check_bindir}
      RESULT_VARIABLE result
      OUTPUT_QUIET


### PR DESCRIPTION
This PR to v4 is an attempt to let f2py work in odd scenarios where perhaps more than one Python stack is in the PATH. In some cases, this is expected (Spack) but in other cases, it is an unsupported way forward (two different Miniforge stacks of different Python vintage).

First, we look for bare `f2py` first as systems like Spack only install that.

Second, we look to see if the Python executable is the same path as the f2py found. If not, we add a `WARNING` to the CMake output. We cannot `FATAL_ERROR` because of things like Spack. 

This is about as good as we can do.

We also add an ugly hack for f2py on macOS with AppleClang because meson and CC and I don't know anymore.