### PR TITLE
v3: Change GCC10+ warnings to status messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.58.0] - 2025-03-24
+
+### Removed
+
+- Removed warning about setting `-fallow-argument-mismatch` and `-fallow-invalid-boz` with GCC 10+. This is pretty much common now. Instead, we emit a message
+
 ## [3.57.0] - 2025-03-18
 
 ### Removed

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -55,38 +55,15 @@ if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
   # First for the argument mismatch
   option(MISMATCH_IS_ERROR "Argument mismatches are errors, not warnings" OFF)
   if (NOT MISMATCH_IS_ERROR)
-    ecbuild_warn (
-      "Argument mismatches will be treated as *warnings* and not *errors*. "
-      "Per the gfortran 10 man page:\n"
-      "Some code contains calls to external procedures which \n"
-      "mismatches between the calls and the procedure definition, \n"
-      "or with mismatches between different calls.  Such code is \n"
-      "non-conforming, and will usually be flagged wi1th an error. \n"
-      "This options degrades the error to a warning, which can \n"
-      "only be disabled by disabling all warnings vial -w.  Only a \n"
-      "single occurrence per argument is flagged by this warning. \n"
-      "-fallow-argument-mismatch is implied by -std=legacy.\n"
-      "Using this option is *strongly* discouraged.  It is possible to \n"
-      "provide standard-conforming code which allows different types \n"
-      "of arguments by using an explicit interface and TYPE(*).")
     set (MISMATCH "-fallow-argument-mismatch")
+    message(STATUS "[GCC10+] Setting -fallow-argument-mismatch to allow argument mismatches")
   endif ()
 
   # Then for BOZ constants
   option(INVALID_BOZ_IS_ERROR "Use of invalid BOZ constants are errors, not warnings" OFF)
   if (NOT INVALID_BOZ_IS_ERROR)
-    ecbuild_warn(
-      "Invalid use of BOZ literal constants will be treated as *warnings* and not as *errors*. "
-      "Per the GCC 10 release notes:\n"
-      "The handling of a BOZ literal constant has been reworked \n"
-      "to provide better conformance to the Fortran 2008 and 2018 \n"
-      "standards. In these Fortran standards, a BOZ literal constant is a \n"
-      "typeless and kindless entity. As a part of the rework, documented \n"
-      "and undocumented extensions to the Fortran standard now emit \n"
-      "errors during compilation. Some of these extensions are permitted \n"
-      "with the -fallow-invalid-boz, where the error is degraded to a \n"
-      "warning and the code is compiled as with older gfortran.")
     set (ALLOW_BOZ "-fallow-invalid-boz")
+    message(STATUS "[GCC10+] Setting -fallow-invalid-boz to allow invalid BOZ constants")
   endif ()
 endif ()
 


### PR DESCRIPTION
Current we emit warnings about using `-fallow-argument-mismatch` and `-fallow-invalid-boz` with GCC 10+ but, well, the code hasn't been changed and probably never will be. Indeed, many packages in Spack, etc do this by default as well.

So, we change the warnings to `STATUS` messages for cleanliness.