### PR TITLE
v3: Fixes for MPT and meson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.59.0] - 2025-04-24
+
+### Changed
+
+- Added a timeout to `mepo status` to prevent it from hanging indefinitely. The timeout is set to 60 seconds
+- Modified the f2py and f2py3 codes for meson+MPT support
+  - It was found that when an f2py code uses MPI, with meson+MPT we need to run with `LD_PRELOAD=/path/to/mpt/libmpi.so`
+
 ## [3.58.2] - 2025-04-22
 
 ### Fixed

--- a/esma_support/esma_mepo_status.cmake
+++ b/esma_support/esma_mepo_status.cmake
@@ -21,6 +21,7 @@ function(esma_capture_mepo_status)
         OUTPUT_FILE "${OUTPUT_FILE}"
         RESULT_VARIABLE MEPO_STATUS_RESULT
         ERROR_QUIET
+        TIMEOUT 60
       )
 
       if(NOT MEPO_STATUS_RESULT EQUAL 0)

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,174 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc

--- a/python/f2py/esma_add_f2py_module.cmake
+++ b/python/f2py/esma_add_f2py_module.cmake
@@ -2,10 +2,37 @@ macro (esma_add_f2py_module name)
 
   add_f2py_module (${name} ${ARGN})
 
+  set(options USE_MPI)
+  cmake_parse_arguments (esma_add_f2py_module "${options}" "" "" ${ARGN})
+
+  # If one of the arguments is USE_MPI we need to
+  # do something special on MPT systems.
+  # First this only matters if we are on Python 3.12 or higher
+  if (Python_VERSION VERSION_GREATER_EQUAL 3.12)
+    message(DEBUG "[F2PY]: Python version is 3.12 or higher, so meson is our backend")
+    message(DEBUG "[F2PY]: MPI_STACK: ${MPI_STACK}")
+    # Next, check if we are using MPI and our stack is 'mpt'
+    message(DEBUG "[F2PY]: Checking for USE_MPI and MPI_STACK=mpt")
+    if(esma_add_f2py_module_USE_MPI AND MPI_STACK STREQUAL "mpt")
+      message(DEBUG "[F2PY]: MPI_Fortran_LIBRARIES: ${MPI_Fortran_LIBRARIES}")
+      # Now we need LD_PRELOAD the libmpi.so found in MPI_Fortran_LIBRARIES
+      # But MPI_Fortran_LIBRARIES is a list, so we need to find the one
+      # that ends with 'libmpi.so'
+      foreach (mpi_lib ${MPI_Fortran_LIBRARIES})
+        if (mpi_lib MATCHES "libmpi.so$")
+          message(DEBUG "[F2PY]: Found libmpi.so: ${mpi_lib}")
+          set(F2PY_PRELOAD "LD_PRELOAD=${mpi_lib}")
+          message(STATUS "[F2PY3]: USE_MPI found and using MPT. Testing will add ${F2PY_PRELOAD}")
+          break()
+        endif()
+      endforeach()
+    endif()
+  endif()
+
   set(UNIT_TEST test_${name})
   add_test (
     NAME ${UNIT_TEST}
-    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" ${Python_EXECUTABLE} -c "import ${name}"
+    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" "${F2PY_PRELOAD}" ${Python_EXECUTABLE} -c "import ${name}"
     )
 
   add_custom_command(
@@ -13,7 +40,7 @@ macro (esma_add_f2py_module name)
     COMMENT "Running Python import test on ${name}"
     POST_BUILD
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" ${Python_EXECUTABLE} -c "import ${name}"
+    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" "${F2PY_PRELOAD}" ${Python_EXECUTABLE} -c "import ${name}"
     )
 
 endmacro ()

--- a/python/f2py3/esma_add_f2py3_module.cmake
+++ b/python/f2py3/esma_add_f2py3_module.cmake
@@ -2,10 +2,37 @@ macro (esma_add_f2py3_module name)
 
   add_f2py3_module (${name} ${ARGN})
 
+  set(options USE_MPI)
+  cmake_parse_arguments (esma_add_f2py3_module "${options}" "" "" ${ARGN})
+
+  # If one of the arguments is USE_MPI we need to
+  # do something special on MPT systems.
+  # First this only matters if we are on Python 3.12 or higher
+  if (Python3_VERSION VERSION_GREATER_EQUAL 3.12)
+    message(DEBUG "[F2PY3]: Python version is 3.12 or higher, so meson is our backend")
+    message(DEBUG "[F2PY3]: MPI_STACK: ${MPI_STACK}")
+    # Next, check if we are using MPI and our stack is 'mpt'
+    message(DEBUG "[F2PY3]: Checking for USE_MPI and MPI_STACK=mpt")
+    if(esma_add_f2py3_module_USE_MPI AND MPI_STACK STREQUAL "mpt")
+      message(DEBUG "[F2PY3]: MPI_Fortran_LIBRARIES: ${MPI_Fortran_LIBRARIES}")
+      # Now we need LD_PRELOAD the libmpi.so found in MPI_Fortran_LIBRARIES
+      # But MPI_Fortran_LIBRARIES is a list, so we need to find the one
+      # that ends with 'libmpi.so'
+      foreach (mpi_lib ${MPI_Fortran_LIBRARIES})
+        if (mpi_lib MATCHES "libmpi.so$")
+          message(DEBUG "[F2PY3]: Found libmpi.so: ${mpi_lib}")
+          set(F2PY3_PRELOAD "LD_PRELOAD=${mpi_lib}")
+          message(STATUS "[F2PY3]: USE_MPI found and using MPT. Testing will add ${F2PY3_PRELOAD}")
+          break()
+        endif()
+      endforeach()
+    endif()
+  endif()
+
   set(UNIT_TEST test_${name})
   add_test (
     NAME ${UNIT_TEST}
-    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" ${Python3_EXECUTABLE} -c "import ${name}"
+    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" "${F2PY3_PRELOAD}" ${Python3_EXECUTABLE} -c "import ${name}"
     )
 
   add_custom_command(
@@ -13,7 +40,7 @@ macro (esma_add_f2py3_module name)
     COMMENT "Running Python3 import test on ${name}"
     POST_BUILD
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" ${Python3_EXECUTABLE} -c "import ${name}"
+    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" "${F2PY3_PRELOAD}" ${Python3_EXECUTABLE} -c "import ${name}"
     )
 
 endmacro ()


### PR DESCRIPTION
This PR has fixes for MPT and meson. It was found that we now need to do `LD_PRELOAD=/path/to/mpt/libmpi.so` when running our `python3 -c 'import f2pyso_'` tests. 

We also set the `mepo status` bit to timeout after 60 seconds.