### PR TITLE
v3: Set CMAKE_INSTALL_LIBDIR to lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Explicitly set `CMAKE_INSTALL_LIBDIR` to `lib` to override `GNUInstallDirs` from setting it to `lib64`. This is mainly needed due to assumptions in GEOS scripting
+
 ### Changed
 
 ### Deprecated

--- a/esma.cmake
+++ b/esma.cmake
@@ -6,6 +6,15 @@ esma_check_install_prefix()
 
 ### ecbuild Support ###
 
+# GEOS' scripting currently assumes `install/lib` is where
+# libraries will be installed. For good or ill, we need to
+# follow this convention. But ecbuild might, via GNUInstallDirs,
+# set it at lib64. This overrides that.
+#
+# NOTE: This must be called *before* including ecbuild (or
+# rather before GNUInstallDirs is included
+set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Libraries")
+
 # Bring in ecbuild
 if (IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/ecbuild")
   list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ecbuild/cmake")


### PR DESCRIPTION
This PR sets `CMAKE_INSTALL_LIBDIR` to `lib`. This is needed as an update (soon) to ecbuild has an `install(GNUInstallDirs)` which sets library installs to `lib64`. But GEOS scripting assumes it'll be in `lib`.