### PR TITLE
v11: Enforce allowed CMAKE_BUILD_TYPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [3.60.0] - 2025-05-02
+## [3.61.0] - 2025-05-06
 
-### Changed
+### Added
+
+- Added code to enforce that we only allow `CMAKE_BUILD_TYPE` of Release, Debug, and Aggressive
+  - CMake can recognize others, but we maintain our own flags so we need to be careful
+
+## [3.60.0] - 2025-05-02
 
 ### Added
 

--- a/compiler/esma_compiler.cmake
+++ b/compiler/esma_compiler.cmake
@@ -8,6 +8,13 @@ message(STATUS "Processor description: ${proc_description}")
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/checks")
 include(check_fortran_support)
 
+## We only allow for three CMake Build Types
+set(ALLOWED_BUILD_TYPES "Debug" "Release" "Aggressive")
+if(NOT CMAKE_BUILD_TYPE IN_LIST ALLOWED_BUILD_TYPES)
+  string(REPLACE ";" ", " ALLOWED_BUILD_TYPES_STRING "${ALLOWED_BUILD_TYPES}")
+  message(FATAL_ERROR "The only allowed CMAKE_BUILD_TYPE are: ${ALLOWED_BUILD_TYPES_STRING}")
+endif()
+
 ## Files with flags for Fortran compilers
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/flags")
 include ("${CMAKE_Fortran_COMPILER_ID}_Fortran")


### PR DESCRIPTION
This PR adds some enforcement to make sure users only ask for our allowed `CMAKE_BUILD_TYPE` variants.