### PR TITLE
v4: Cache proc_description variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make `proc_description` a `CACHE` variable
+
 ### Deprecated
 
 ## [4.17.0] - 2025-05-06

--- a/compiler/esma_compiler.cmake
+++ b/compiler/esma_compiler.cmake
@@ -3,6 +3,7 @@
 ## Print out the processor description
 cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
 message(STATUS "Processor description: ${proc_description}")
+set(proc_description "${proc_description}" CACHE INTERNAL "Processor description")
 
 ## Checks for Fortran support
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/checks")


### PR DESCRIPTION
This caches the `proc_description` variable for use in https://github.com/GEOS-ESM/GEOSgcm/pull/930