### PR TITLE
v4: Fix f2py TMPDIR issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.18.1] - 2025-05-22
+
+### Changed
+
+- Added `TMPDIR` environment variable to f2py and f2py3 compilation processes in CMake scripts to avoid `noexec` `/tmp` directories
+
 ## [4.18.0] - 2025-05-13
 
 ### Fixed

--- a/python/f2py/try_f2py_compile.cmake
+++ b/python/f2py/try_f2py_compile.cmake
@@ -32,6 +32,7 @@ macro (try_f2py_compile file var)
    message(DEBUG "MESON_CCOMPILER is set to ${MESON_CCOMPILER}")
    list(APPEND ENV_LIST FC=${MESON_F2PY_FCOMPILER})
    list(APPEND ENV_LIST CC=${MESON_CCOMPILER})
+   list(APPEND ENV_LIST TMPDIR=${_f2py_check_bindir})
    message(DEBUG "ENV_LIST is set to ${ENV_LIST}")
    execute_process(
      COMMAND cmake -E env ${ENV_LIST} ${F2PY_EXECUTABLE} -m test_ -c ${file} --fcompiler=${F2PY_FCOMPILER}

--- a/python/f2py3/try_f2py3_compile.cmake
+++ b/python/f2py3/try_f2py3_compile.cmake
@@ -32,6 +32,7 @@ macro (try_f2py3_compile file var)
    message(DEBUG "MESON_CCOMPILER is set to ${MESON_CCOMPILER}")
    list(APPEND ENV_LIST FC=${MESON_F2PY3_FCOMPILER})
    list(APPEND ENV_LIST CC=${MESON_CCOMPILER})
+   list(APPEND ENV_LIST TMPDIR=${_f2py3_check_bindir})
    message(DEBUG "ENV_LIST is set to ${ENV_LIST}")
    execute_process(
      COMMAND cmake -E env ${ENV_LIST} ${F2PY3_EXECUTABLE} -m test_ -c ${file} --fcompiler=${F2PY3_FCOMPILER}


### PR DESCRIPTION
This PR fixes an issue found on a machine where `TMPDIR` was pointing to a `noexec` directory. This was causing our f2py tests to fail.