### PR TITLE
v4: Fixes for FV_PRECISION handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.19.1] - 2025-07-08
+
+### Fixed
+
+- Fix for FMS1 I/O test in CMake to handle different `FV_PRECISION` cases
+
 ## [4.19.0] - 2025-07-03
 
 ### Changed

--- a/external_libraries/check_fms1_io_support.cmake
+++ b/external_libraries/check_fms1_io_support.cmake
@@ -3,8 +3,14 @@ set(_CHECK_FMS1_IO_SUPPORT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 macro(check_fms1_io_support result_var)
   # Get include directories from the FMS target
-  get_target_property(FMS_INCLUDE_DIRS FMS::fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
-  
+  # We default to FMS::fms_r4
+  set(FMS_TARGET FMS::fms_r4)
+  # but if FV_PRECISION is set to R8, we use FMS::fms_r8
+  if(FV_PRECISION STREQUAL R8)
+    set(FMS_TARGET FMS::fms_r8)
+  endif()
+  get_target_property(FMS_INCLUDE_DIRS ${FMS_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
+
   # Handle cases where properties might not be set
   if(NOT FMS_INCLUDE_DIRS)
     set(FMS_INCLUDE_DIRS "")


### PR DESCRIPTION
This PR fixes an issue with the FMS1 I/O test from #462 which didn't handle the `FV_PRECISION=R8` case correctly.