### PR TITLE
v3: Fix issue with libaec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.27.0
+#baselibs_version: &baselibs_version v8.18.0
 #bcs_version: &bcs_version v11.6.0
 
 orbs:

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -30,3 +30,4 @@ jobs:
           labels: "Contingent - DNA,Needs Lead Approval,Contingent -- Do Not Approve"
           add_comment: true
           message: "This PR is being prevented from merging because you have added one of our blocking labels: {{ provided }}. You'll need to remove it before this PR can be merged."
+

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,7 +21,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-24.04
     container:
-      image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.18.0-intelmpi_2021.13-ifort_2021.13
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.63.1] - 2025-09-03
+
+### Fixed
+
+- Fix issue with libaec use (use LIST instead of string)
+
 ## [3.63.0] - 2025-08-25
 
 ### Added

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -262,21 +262,24 @@ if (Baselibs_FOUND)
   # can set SZ_LIB to "sz aec", otherwise we set it to just "sz".
   # We should also check to see if sz is there as well! If it isn't
   # we set SZ_LIB to "".
-  set (SZ_LIB "")
+  set (SZ_LIB)
   if (EXISTS ${BASEDIR}/lib/libaec.a)
     # If we have libaec, then we use it
-    set (SZ_LIB "sz aec")
+    list (APPEND SZ_LIB sz aec)
     message(DEBUG "Found libaec in BASEDIR/lib. Using sz aec for SZ_LIB.")
   elseif (EXISTS ${BASEDIR}/lib/libsz.a)
     # We don't have libaec, but we do have sz
-    set (SZ_LIB "sz")
+    list (APPEND SZ_LIB sz)
     message(DEBUG "Did not find libaec in BASEDIR/lib. Using sz for SZ_LIB.")
   else ()
     # We don't have sz or libaec
     message(DEBUG "Did not find libsz or libaec in BASEDIR/lib. Not using sz or aec for SZ_LIB.")
   endif ()
 
-  set (HDF5_LIBRARIES hdf5_hl_fortran hdf5_fortran hdf5_hl hdf5 ${SZ_LIB} z m dl)
+  set (HDF5_LIBRARIES
+    hdf5_hl_fortran hdf5_fortran hdf5_hl hdf5
+    ${SZ_LIB}
+    z m dl)
   # Create targets
 
   # - HDF5 C


### PR DESCRIPTION
A GEOSadas build detected a CMake issue with my handling of how I added libaec support. My first attempt was fragile and broke because I used a string instead of a list. This fixes that.