### PR TITLE
v4: Fixes for ifx 2025.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.23.0] - 2025-09-23
+
+### Fixed
+
+- Workaround for `ifx` 2025.2 preprocessor bug
+
 ## [4.22.0] - 2025-09-09
 
 ### Changed


### PR DESCRIPTION
This PR has a CMake workaround for an ifx 2025.2 bug in their preprocessor, see https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735

This bug will be fixed in ifx 2025.3, but there is a need to get ifx 2025.2 working (as it fixes bugs in other repos, e.g., fms).

NOTE: To fully use ifx 2025.2 will require a new Baselibs with updates to GFE as well as updates to MAPL and other repos. But this is needed here.