### PR TITLE
Fix missing FPE1 in Intel flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.23.1] - 2025-09-26
+
+### Fixed
+
+- Corrected missing `FPE1` in Intel flags
+
 ## [4.23.0] - 2025-09-23
 
 ### Fixed

--- a/compiler/flags/IntelLLVM_Fortran.cmake
+++ b/compiler/flags/IntelLLVM_Fortran.cmake
@@ -10,6 +10,7 @@ set (FOPT4 "-O4")
 set (DEBINFO "-g")
 
 set (FPE0 "-fpe0")
+set (FPE1 "-fpe1")
 set (FPE3 "-fpe3")
 # ifx does not support -fp-model source (yet? see https://www.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/compiler-reference/compiler-options/floating-point-options/fp-model-fp.html)
 #set (FP_MODEL_SOURCE "-fp-model source")

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -12,6 +12,7 @@ set (FFAST "-fast")
 set (DEBINFO "-g")
 
 set (FPE0 "-fpe0")
+set (FPE1 "-fpe1")
 set (FPE3 "-fpe3")
 set (FP_MODEL_PRECISE "-fp-model precise")
 set (FP_MODEL_EXCEPT "-fp-model except")


### PR DESCRIPTION
As found by @wmputman, we were using `${FPE1}` for ifort without defining it. oops.