### PR TITLE
v4: Add new VectTrap flags (only tested on Intel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `ifx` flags to match as close as possible to `ifort` flags
+
 ### Deprecated
 
 ## [4.25.0] - 2025-10-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.25.0] - 2025-10-02
+
+### Added
+
+- Add new "VectTrap" `CMAKE_BUILD_TYPE`. This is only different from `Release` for Intel Fortran. It is a set of flags to try to trap exceptions (e.g., invalid floating point operations) while still being vectorized.
+
 ## [4.24.0] - 2025-10-02
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `ifx` flags to match as close as possible to `ifort` flags
-
 ### Deprecated
 
 ## [4.25.0] - 2025-10-02
@@ -24,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add new "VectTrap" `CMAKE_BUILD_TYPE`. This is only different from `Release` for Intel Fortran. It is a set of flags to try to trap exceptions (e.g., invalid floating point operations) while still being vectorized.
+
+### Changed
+
+- Update `ifx` flags to be close to `ifort` flags (ish)
+  - NOTE: ifx is still in testing and flags will change (currently does not layout-regress)
 
 ## [4.24.0] - 2025-10-02
 

--- a/compiler/esma_compiler.cmake
+++ b/compiler/esma_compiler.cmake
@@ -10,7 +10,7 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/checks")
 include(check_fortran_support)
 
 ## We only allow for three CMake Build Types
-set(ALLOWED_BUILD_TYPES "Debug" "Release" "Aggressive")
+set(ALLOWED_BUILD_TYPES "Debug" "Release" "Aggressive" "VectTrap")
 if(NOT CMAKE_BUILD_TYPE IN_LIST ALLOWED_BUILD_TYPES)
   string(REPLACE ";" ", " ALLOWED_BUILD_TYPES_STRING "${ALLOWED_BUILD_TYPES}")
   message(FATAL_ERROR "The only allowed CMAKE_BUILD_TYPE are: ${ALLOWED_BUILD_TYPES_STRING}")

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -185,6 +185,12 @@ set (GEOS_Fortran_NoVect_FPE_Flags "${GEOS_Fortran_Release_FPE_Flags}")
 set (GEOS_Fortran_Vect_Flags ${GEOS_Fortran_Release_Flags})
 set (GEOS_Fortran_Vect_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
 
+# GEOS VectTrap
+# --------------
+# Until good options can be found, make vecttrap equal common flags
+set (GEOS_Fortran_VectTrap_Flags ${GEOS_Fortran_Release_Flags})
+set (GEOS_Fortran_VectTrap_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
+
 # GEOS Aggressive
 # ---------------
 # NOTE: gfortran does get a benefit from vectorization, but the resulting code

--- a/compiler/flags/Generic_Fortran.cmake
+++ b/compiler/flags/Generic_Fortran.cmake
@@ -2,8 +2,10 @@ set (GEOS_Fortran_FLAGS_DEBUG       "${GEOS_Fortran_Debug_Flags} ${common_Fortra
 set (GEOS_Fortran_FLAGS_RELEASE     "${GEOS_Fortran_Release_Flags} ${common_Fortran_flags} ${GEOS_Fortran_Release_FPE_Flags} ${ALIGNCOM}")
 set (GEOS_Fortran_FLAGS_VECT        "${GEOS_Fortran_Vect_Flags} ${common_Fortran_flags} ${GEOS_Fortran_Vect_FPE_Flags} ${ALIGNCOM}")
 set (GEOS_Fortran_FLAGS_NOVECT      "${GEOS_Fortran_NoVect_Flags} ${common_Fortran_flags} ${GEOS_Fortran_NoVect_FPE_Flags} ${ALIGNCOM}")
+set (GEOS_Fortran_FLAGS_VECTTRAP    "${GEOS_Fortran_VectTrap_Flags} ${common_Fortran_flags} ${GEOS_Fortran_VectTrap_FPE_Flags} ${ALIGNCOM}")
 set (GEOS_Fortran_FLAGS_AGGRESSIVE  "${GEOS_Fortran_Aggressive_Flags} ${common_Fortran_flags} ${GEOS_Fortran_Aggressive_FPE_Flags} ${ALIGNCOM}")
 
 set (CMAKE_Fortran_FLAGS_DEBUG      "${GEOS_Fortran_FLAGS_DEBUG}"      CACHE STRING "Debug Fortran flags"      FORCE )
 set (CMAKE_Fortran_FLAGS_RELEASE    "${GEOS_Fortran_FLAGS_RELEASE}"    CACHE STRING "Release Fortran flags"    FORCE )
+set (CMAKE_Fortran_FLAGS_VECTTRAP   "${GEOS_Fortran_FLAGS_VECTTRAP}"   CACHE STRING "VectTrap Fortran flags"   FORCE )
 set (CMAKE_Fortran_FLAGS_AGGRESSIVE "${GEOS_Fortran_FLAGS_AGGRESSIVE}" CACHE STRING "Aggressive Fortran flags" FORCE )

--- a/compiler/flags/IntelLLVM_Fortran.cmake
+++ b/compiler/flags/IntelLLVM_Fortran.cmake
@@ -2,6 +2,9 @@ if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 2025.1)
   message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 2025.1!")
 endif()
 
+# ----------------------------------------------------------------------
+# Optimization levels
+# ----------------------------------------------------------------------
 set (FOPT0 "-O0")
 set (FOPT1 "-O1")
 set (FOPT2 "-O2")
@@ -9,31 +12,54 @@ set (FOPT3 "-O3")
 set (FOPT4 "-O4")
 set (FFAST "-fast")
 
+# Debug info
 set (DEBINFO "-g")
 
+# ----------------------------------------------------------------------
+# Floating-point handling
+# ----------------------------------------------------------------------
 set (FPE0 "-fpe0")
 set (FPE1 "-fpe1")
 set (FPE3 "-fpe3")
-set (FP_MODEL_PRECISE "-fp-model precise")
-set (FP_MODEL_EXCEPT "-fp-model except")
-set (FP_MODEL_SOURCE "-fp-model source")
-set (FP_MODEL_STRICT "-fp-model strict")
-set (FP_MODEL_CONSISTENT "-fp-model consistent")
-set (FP_MODEL_FAST "-fp-model fast")
-set (FP_MODEL_FAST1 "-fp-model fast=1")
-set (FP_MODEL_FAST2 "-fp-model fast=2")
 
+# Grouped FP models
+set (FP_SOURCE     "-fp-model source")
+set (FP_CONSISTENT "-fp-model consistent")
+set (FP_EXCEPT     "-fp-model except")
+set (FP_PRECISE    "-fp-model precise")
+set (FP_STRICT     "-fp-model strict")
+set (FP_FAST       "-fp-model fast")
+set (FP_FAST1      "-fp-model fast=1")
+set (FP_FAST2      "-fp-model fast=2")
+
+# -fp-speculation=fast is the compiler default
+set (FP_SPECULATION_FAST   "-fp-speculation=fast")
 # Testing with ifx 2025.2 found these flags caused a lot
 # of ICEs. For now we turn off
 #set (FP_SPECULATION_SAFE "-fp-speculation=safe")
 #set (FP_SPECULATION_STRICT "-fp-speculation=strict")
 
-set (OPTREPORT0 "-qopt-report0")
-set (OPTREPORT5 "-qopt-report5")
+set (ARCH_CONSISTENCY "-fimf-arch-consistency=true")
 
+set (FTZ "-ftz")
+set (NO_PREC_DIV "-no-prec-div")
+set (USE_SVML "-fimf-use-svml=true ")
+
+set (IPO "-ipo")
+set (FMA "-fma")
+set (NO_FMA "-no-fma")
 set (FREAL8 "-r8")
 set (FINT8 "-i8")
 
+# ----------------------------------------------------------------------
+# Reports
+# ----------------------------------------------------------------------
+set (OPTREPORT0 "-qopt-report0")
+set (OPTREPORT5 "-qopt-report5")
+
+# ----------------------------------------------------------------------
+# Portability / source format
+# ----------------------------------------------------------------------
 set(PP "-fpp") # default for all other versions
 if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 2025.2 AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 2025.3)
 
@@ -67,30 +93,35 @@ exec \"${cpp_exe}\" -P -traditional-cpp -undef \"$@\"
   endif()
 endif()
 
-set (MISMATCH "")
 set (BIG_ENDIAN "-convert big_endian")
 set (LITTLE_ENDIAN "-convert little_endian")
 set (EXTENDED_SOURCE "-extend-source")
 set (FIXED_SOURCE "-fixed")
+set (NO_RANGE_CHECK "")
+
+# ----------------------------------------------------------------------
+# Warnings / diagnostics
+# ----------------------------------------------------------------------
 set (DISABLE_FIELD_WIDTH_WARNING "-diag-disable 8291")
 set (DISABLE_GLOBAL_NAME_WARNING "-diag-disable 5462")
-set (CRAY_POINTER "")
-set (MCMODEL "-mcmodel medium -shared-intel")
-set (HEAPARRAYS "-heap-arrays 32")
-set (BYTERECLEN "-assume byterecl")
-set (ALIGNCOM "-align dcommons")
-set (TRACEBACK "-traceback")
-set (NOOLD_MAXMINLOC "-assume noold_maxminloc")
-set (REALLOC_LHS "-assume realloc_lhs")
-set (ARCH_CONSISTENCY "-fimf-arch-consistency=true")
-set (FTZ "-ftz")
-set (FMA "-fma")
-set (NO_FMA "-no-fma")
-set (ALIGN_ALL "-align all")
-set (NO_ALIAS "-fno-alias")
-set (USE_SVML "-fimf-use-svml=true")
+set (DISABLE_10337 "-diag-disable 10337")   # fno-builtin warning
+set (DISABLE_10121 "-diag-disable 10121")   # fp-model override warning
+set (DISABLE_10448 "-diag-disable 10448")   # ifort deprecation remark
+set (DISABLE_LONG_LINE_LENGTH_WARNING "-diag-disable 5268")
 
-# Additional flags for better Standards compliance
+# Make an option to make things quiet during debug builds
+option (QUIET_DEBUG "Suppress excess compiler output during debug builds" OFF)
+if (QUIET_DEBUG)
+  set (WARN_UNUSED "")
+  set (SUPPRESS_COMMON_WARNINGS "${DISABLE_FIELD_WIDTH_WARNING} ${DISABLE_GLOBAL_NAME_WARNING} ${DISABLE_10337}")
+else ()
+  set (WARN_UNUSED "-warn unused")
+  set (SUPPRESS_COMMON_WARNINGS "${DISABLE_GLOBAL_NAME_WARNING} ${DISABLE_10337}")
+endif ()
+
+# ----------------------------------------------------------------------
+# Standards Compliance (used in MAPL)
+# ----------------------------------------------------------------------
 ## Set the Standard to be Fortran 2018
 set (STANDARD_F18 "-stand f18")
 ## Error out if you try to do if(integer)
@@ -100,7 +131,20 @@ set (ERROR_LOGICAL_SET_TO_INTEGER "-diag-error 6192")
 ## Turn off warning #5268 (Extension to standard: The text exceeds right hand column allowed on the line.)
 set (DISABLE_LONG_LINE_LENGTH_WARNING "-diag-disable 5268")
 
-set (NO_RANGE_CHECK "")
+# ----------------------------------------------------------------------
+# Memory / alignment
+# ----------------------------------------------------------------------
+set (MCMODEL "-mcmodel medium -shared-intel")
+set (HEAPARRAYS "-heap-arrays 32")
+set (BYTERECLEN "-assume byterecl")
+set (TRACEBACK "-traceback")
+set (NOOLD_MAXMINLOC "-assume noold_maxminloc")
+set (REALLOC_LHS "-assume realloc_lhs")
+set (ALIGNCOM "-align dcommons")
+set (NO_ALIAS "-fno-alias")
+set (ALIGN_ALL "-align all")
+set (ARRAY_ALIGN_32BYTE "-align array32byte")
+set (ARRAY_ALIGN_64BYTE "-align array64byte")
 
 cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
 if (${proc_description} MATCHES "EPYC")
@@ -120,29 +164,33 @@ else ()
   message(FATAL_ERROR "Unknown processor. Please file an issue at https://github.com/GEOS-ESM/ESMA_cmake")
 endif ()
 
+# ----------------------------------------------------------------------
+# Defines
+# ----------------------------------------------------------------------
 add_definitions(-DHAVE_SHMEM)
 
-####################################################
-
-# Common Fortran Flags
-# --------------------
+# ----------------------------------------------------------------------
+# Common flag bundles
+# ----------------------------------------------------------------------
 set (common_Fortran_flags "${TRACEBACK} ${REALLOC_LHS} ${OPTREPORT0} ${ALIGN_ALL} ${NO_ALIAS} ${PP}")
 set (common_Fortran_fpe_flags "${FTZ} ${NOOLD_MAXMINLOC}")
 
-# GEOS Debug
-# ----------
+# ----------------------------------------------------------------------
+# Build type specific bundles
+# ----------------------------------------------------------------------
+# Debug
 set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -check all,noarg_temp_created,nouninit ${WARN_UNUSED} -init=snan,arrays -save-temps")
-set (GEOS_Fortran_Debug_FPE_Flags "${FPE0} ${FP_MODEL_STRICT} ${FP_SPECULATION_STRICT} ${common_Fortran_fpe_flags} ${SUPPRESS_COMMON_WARNINGS}")
+set (GEOS_Fortran_Debug_FPE_Flags "${FPE0} ${FP_STRICT} ${FP_SPECULATION_STRICT} ${common_Fortran_fpe_flags} ${SUPPRESS_COMMON_WARNINGS}")
 
 # GEOS Safe
 # ----------------
 set (GEOS_Fortran_Safe_Flags "${FOPT2} ${DEBINFO}")
-set (GEOS_Fortran_Safe_FPE_Flags "${FPE1} ${FP_MODEL_PRECISE} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_STRICT} ${common_Fortran_fpe_flags}")
+set (GEOS_Fortran_Safe_FPE_Flags "${FPE1} ${FP_PRECISE} ${FP_SOURCE} ${FP_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_STRICT} ${common_Fortran_fpe_flags}")
 
 # GEOS NoVectorize
 # ----------------
 set (GEOS_Fortran_NoVect_Flags "${FOPT3} ${DEBINFO}")
-set (GEOS_Fortran_NoVect_FPE_Flags "${FPE1} ${FP_MODEL_FAST1} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
+set (GEOS_Fortran_NoVect_FPE_Flags "${FPE1} ${FP_FAST1} ${FP_SOURCE} ${FP_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
 
 # NOTE It was found that the Vectorizing Flags gave better performance with the same results in testing.
 #      But in case they are needed, we keep the older flags available
@@ -150,17 +198,17 @@ set (GEOS_Fortran_NoVect_FPE_Flags "${FPE1} ${FP_MODEL_FAST1} ${FP_MODEL_SOURCE}
 # GEOS Stock-Vect
 # ---------------
 set (GEOS_Fortran_StockVect_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} ${FMA} -align array32byte")
-set (GEOS_Fortran_StockVect_FPE_Flags "${FPE3} ${FP_MODEL_FAST} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${common_Fortran_fpe_flags}")
+set (GEOS_Fortran_StockVect_FPE_Flags "${FPE3} ${FP_FAST} ${FP_SOURCE} ${FP_CONSISTENT} ${common_Fortran_fpe_flags}")
 
 # GEOS Vectorize
 # ---------------
 set (GEOS_Fortran_Vect_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -align array32byte")
-set (GEOS_Fortran_Vect_FPE_Flags "${FPE1} ${FP_MODEL_FAST1} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
+set (GEOS_Fortran_Vect_FPE_Flags "${FPE1} ${FP_FAST1} ${FP_SOURCE} ${FP_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
 
 # GEOS Aggressive
 # ---------------
 set (GEOS_Fortran_Aggressive_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -align array32byte")
-set (GEOS_Fortran_Aggressive_FPE_Flags "${FPE3} ${FP_MODEL_FAST2} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${FMA} ${FP_SPECULATION_FAST} ${USE_SVML} ${common_Fortran_fpe_flags}")
+set (GEOS_Fortran_Aggressive_FPE_Flags "${FPE3} ${FP_FAST2} ${FP_SOURCE} ${FP_CONSISTENT} ${FMA} ${FP_SPECULATION_FAST} ${USE_SVML} ${common_Fortran_fpe_flags}")
 
 # Set Release flags
 # -----------------

--- a/compiler/flags/IntelLLVM_Fortran.cmake
+++ b/compiler/flags/IntelLLVM_Fortran.cmake
@@ -1,5 +1,5 @@
-if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 15.1)
-  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 15.1!")
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 2025.1)
+  message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 2025.1!")
 endif()
 
 set (FOPT0 "-O0")
@@ -7,20 +7,26 @@ set (FOPT1 "-O1")
 set (FOPT2 "-O2")
 set (FOPT3 "-O3")
 set (FOPT4 "-O4")
+set (FFAST "-fast")
+
 set (DEBINFO "-g")
 
 set (FPE0 "-fpe0")
 set (FPE1 "-fpe1")
 set (FPE3 "-fpe3")
-# ifx does not support -fp-model source (yet? see https://www.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/compiler-reference/compiler-options/floating-point-options/fp-model-fp.html)
-#set (FP_MODEL_SOURCE "-fp-model source")
-set (FP_MODEL_SOURCE "")
+set (FP_MODEL_PRECISE "-fp-model precise")
+set (FP_MODEL_EXCEPT "-fp-model except")
+set (FP_MODEL_SOURCE "-fp-model source")
 set (FP_MODEL_STRICT "-fp-model strict")
-# ifx does not support -fp-model consistent (yet? see https://www.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/compiler-reference/compiler-options/floating-point-options/fp-model-fp.html)
-#set (FP_MODEL_CONSISTENT "-fp-model consistent")
-set (FP_MODEL_CONSISTENT "")
+set (FP_MODEL_CONSISTENT "-fp-model consistent")
+set (FP_MODEL_FAST "-fp-model fast")
 set (FP_MODEL_FAST1 "-fp-model fast=1")
 set (FP_MODEL_FAST2 "-fp-model fast=2")
+
+# Testing with ifx 2025.2 found these flags caused a lot
+# of ICEs. For now we turn off
+#set (FP_SPECULATION_SAFE "-fp-speculation=safe")
+#set (FP_SPECULATION_STRICT "-fp-speculation=strict")
 
 set (OPTREPORT0 "-qopt-report0")
 set (OPTREPORT5 "-qopt-report5")
@@ -78,6 +84,8 @@ set (NOOLD_MAXMINLOC "-assume noold_maxminloc")
 set (REALLOC_LHS "-assume realloc_lhs")
 set (ARCH_CONSISTENCY "-fimf-arch-consistency=true")
 set (FTZ "-ftz")
+set (FMA "-fma")
+set (NO_FMA "-no-fma")
 set (ALIGN_ALL "-align all")
 set (NO_ALIAS "-fno-alias")
 set (USE_SVML "-fimf-use-svml=true")
@@ -118,37 +126,46 @@ add_definitions(-DHAVE_SHMEM)
 
 # Common Fortran Flags
 # --------------------
-set (common_Fortran_flags "${TRACEBACK} ${REALLOC_LHS} ${PP}")
-set (common_Fortran_fpe_flags "${FPE0} ${FP_MODEL_SOURCE} ${HEAPARRAYS} ${NOOLD_MAXMINLOC}")
+set (common_Fortran_flags "${TRACEBACK} ${REALLOC_LHS} ${OPTREPORT0} ${ALIGN_ALL} ${NO_ALIAS} ${PP}")
+set (common_Fortran_fpe_flags "${FTZ} ${NOOLD_MAXMINLOC}")
 
 # GEOS Debug
 # ----------
-set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -check all,noarg_temp_created,nouninit -warn unused -save-temps")
-set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
+set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -check all,noarg_temp_created,nouninit ${WARN_UNUSED} -init=snan,arrays -save-temps")
+set (GEOS_Fortran_Debug_FPE_Flags "${FPE0} ${FP_MODEL_STRICT} ${FP_SPECULATION_STRICT} ${common_Fortran_fpe_flags} ${SUPPRESS_COMMON_WARNINGS}")
+
+# GEOS Safe
+# ----------------
+set (GEOS_Fortran_Safe_Flags "${FOPT2} ${DEBINFO}")
+set (GEOS_Fortran_Safe_FPE_Flags "${FPE1} ${FP_MODEL_PRECISE} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_STRICT} ${common_Fortran_fpe_flags}")
 
 # GEOS NoVectorize
 # ----------------
-set (GEOS_Fortran_NoVect_Flags "${FOPT3} ${DEBINFO} ${OPTREPORT0} ${FTZ} ${ALIGN_ALL} ${NO_ALIAS}")
-set (GEOS_Fortran_NoVect_FPE_Flags "${common_Fortran_fpe_flags} ${ARCH_CONSISTENCY}")
+set (GEOS_Fortran_NoVect_Flags "${FOPT3} ${DEBINFO}")
+set (GEOS_Fortran_NoVect_FPE_Flags "${FPE1} ${FP_MODEL_FAST1} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
 
 # NOTE It was found that the Vectorizing Flags gave better performance with the same results in testing.
 #      But in case they are needed, we keep the older flags available
 
-# GEOS Vectorize
-# --------------
-set (GEOS_Fortran_Vect_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -fma -qopt-report0 ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -align array32byte")
-set (GEOS_Fortran_Vect_FPE_Flags "${FPE3} ${FP_MODEL_CONSISTENT} ${NOOLD_MAXMINLOC}")
+# GEOS Stock-Vect
+# ---------------
+set (GEOS_Fortran_StockVect_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} ${FMA} -align array32byte")
+set (GEOS_Fortran_StockVect_FPE_Flags "${FPE3} ${FP_MODEL_FAST} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${common_Fortran_fpe_flags}")
 
-# GEOS Release
-# ------------
-set (GEOS_Fortran_Release_Flags  "${GEOS_Fortran_Vect_Flags}")
-set (GEOS_Fortran_Release_FPE_Flags "${GEOS_Fortran_Vect_FPE_Flags}")
+# GEOS Vectorize
+# ---------------
+set (GEOS_Fortran_Vect_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -align array32byte")
+set (GEOS_Fortran_Vect_FPE_Flags "${FPE1} ${FP_MODEL_FAST1} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
 
 # GEOS Aggressive
 # ---------------
-set (GEOS_Fortran_Aggressive_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -fma -qopt-report0 ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -align array32byte")
-#set (GEOS_Fortran_Aggressive_Flags "${FOPT3} ${DEBINFO} -xSKYLAKE-AVX512 -qopt-zmm-usage=high -fma -qopt-report0 ${FTZ} ${ALIGN_ALL} ${NO_ALIAS} -align array64byte")
-set (GEOS_Fortran_Aggressive_FPE_Flags "${FPE3} ${FP_MODEL_FAST2} ${USE_SVML} ${NOOLD_MAXMINLOC}")
+set (GEOS_Fortran_Aggressive_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -align array32byte")
+set (GEOS_Fortran_Aggressive_FPE_Flags "${FPE3} ${FP_MODEL_FAST2} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${FMA} ${FP_SPECULATION_FAST} ${USE_SVML} ${common_Fortran_fpe_flags}")
+
+# Set Release flags
+# -----------------
+set (GEOS_Fortran_Release_Flags  "${GEOS_Fortran_Vect_Flags}")
+set (GEOS_Fortran_Release_FPE_Flags "${GEOS_Fortran_Vect_FPE_Flags}")
 
 # Common variables for every compiler
 include(Generic_Fortran)

--- a/compiler/flags/IntelLLVM_Fortran.cmake
+++ b/compiler/flags/IntelLLVM_Fortran.cmake
@@ -205,6 +205,12 @@ set (GEOS_Fortran_StockVect_FPE_Flags "${FPE3} ${FP_FAST} ${FP_SOURCE} ${FP_CONS
 set (GEOS_Fortran_Vect_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -align array32byte")
 set (GEOS_Fortran_Vect_FPE_Flags "${FPE1} ${FP_FAST1} ${FP_SOURCE} ${FP_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
 
+# GEOS VectTrap
+# -------------
+# Until these can be tested, we just use the same as GEOS_Vectorize
+set (GEOS_Fortran_VectTrap_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -align array32byte")
+set (GEOS_Fortran_VectTrap_FPE_Flags "${FPE1} ${FP_FAST1} ${FP_SOURCE} ${FP_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
+
 # GEOS Aggressive
 # ---------------
 set (GEOS_Fortran_Aggressive_Flags "${FOPT3} ${DEBINFO} ${MARCH_FLAG} -align array32byte")

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -86,6 +86,18 @@ else ()
 endif ()
 
 # ----------------------------------------------------------------------
+# Standards Compliance (used in MAPL)
+# ----------------------------------------------------------------------
+## Set the Standard to be Fortran 2018
+set (STANDARD_F18 "-stand f18")
+## Error out if you try to do if(integer)
+set (ERROR_IF_INTEGER "-diag-error 6188")
+## Error out if you try to set a logical to an integer
+set (ERROR_LOGICAL_SET_TO_INTEGER "-diag-error 6192")
+## Turn off warning #5268 (Extension to standard: The text exceeds right hand column allowed on the line.)
+set (DISABLE_LONG_LINE_LENGTH_WARNING "-diag-disable 5268")
+
+# ----------------------------------------------------------------------
 # Memory / alignment
 # ----------------------------------------------------------------------
 set (MCMODEL "-mcmodel medium -shared-intel")
@@ -193,4 +205,3 @@ set (GEOS_Fortran_Release_FPE_Flags "${GEOS_Fortran_Vect_FPE_Flags}")
 
 # Common variables for every compiler
 include(Generic_Fortran)
-

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -118,7 +118,7 @@ elseif ( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64" )
   # for most x86_64 processors, but it is not guaranteed to be optimal.
   message(WARNING "Unknown processor type. Defaulting to a generic x86_64 processor. Performance may be suboptimal.")
   set (COREAVX2_FLAG "")
-  # Once you are in here, you are probably on Rosetta, but not required. 
+  # Once you are in here, you are probably on Rosetta, but not required.
   # Still, on Apple Rosetta we also now need to use the ld_classic as the linker
   if (APPLE)
     # Determine whether we need to add link options for version 15+ of the Apple command line utilities
@@ -160,7 +160,7 @@ set (GEOS_Fortran_Debug_FPE_Flags "${FPE0} ${FP_MODEL_STRICT} ${FP_SPECULATION_S
 # Strict (bitwise reproducible, IEEE-compliant)
 set (GEOS_Fortran_Strict_Flags "${FOPT2} ${DEBINFO}")
 set (GEOS_Fortran_Strict_FPE_Flags
-     "${FP_STRICT} ${FP_SPECULATION_STRICT} ${FPE0} -check uninit -prec-div -prec-sqrt -no-ftz ${common_Fortran_fpe_flags}") 
+     "${FP_STRICT} ${FP_SPECULATION_STRICT} ${FPE0} -check uninit -prec-div -prec-sqrt -no-ftz ${common_Fortran_fpe_flags}")
 
 # NoVect (bitwise stable, no FMA)
 set (GEOS_Fortran_NoVect_Flags

--- a/compiler/flags/Intel_Fortran.cmake
+++ b/compiler/flags/Intel_Fortran.cmake
@@ -2,6 +2,9 @@ if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 15.1)
   message(FATAL_ERROR "${CMAKE_Fortran_COMPILER_ID} version must be at least 15.1!")
 endif()
 
+# ----------------------------------------------------------------------
+# Optimization levels
+# ----------------------------------------------------------------------
 set (FOPT0 "-O0")
 set (FOPT1 "-O1")
 set (FOPT2 "-O2")
@@ -9,73 +12,92 @@ set (FOPT3 "-O3")
 set (FOPT4 "-O4")
 set (FFAST "-fast")
 
+# Debug info
 set (DEBINFO "-g")
 
+# ----------------------------------------------------------------------
+# Floating-point handling
+# ----------------------------------------------------------------------
 set (FPE0 "-fpe0")
 set (FPE1 "-fpe1")
 set (FPE3 "-fpe3")
-set (FP_MODEL_PRECISE "-fp-model precise")
-set (FP_MODEL_EXCEPT "-fp-model except")
-set (FP_MODEL_SOURCE "-fp-model source")
-set (FP_MODEL_STRICT "-fp-model strict")
-set (FP_MODEL_CONSISTENT "-fp-model consistent")
-set (FP_MODEL_FAST "-fp-model fast")
-set (FP_MODEL_FAST1 "-fp-model fast=1")
-set (FP_MODEL_FAST2 "-fp-model fast=2")
 
-set (FP_SPECULATION_SAFE "-fp-speculation=safe")
+# Grouped FP models
+set (FP_SOURCE     "-fp-model source")
+set (FP_CONSISTENT "-fp-model consistent")
+set (FP_EXCEPT     "-fp-model except")
+set (FP_PRECISE    "-fp-model precise")
+set (FP_STRICT     "-fp-model strict")
+set (FP_FAST       "-fp-model fast")
+set (FP_FAST1      "-fp-model fast=1")
+set (FP_FAST2      "-fp-model fast=2")
+
+# -fp-speculation=fast is the compiler default
+set (FP_SPECULATION_FAST   "-fp-speculation=fast")
+set (FP_SPECULATION_SAFE   "-fp-speculation=safe")
 set (FP_SPECULATION_STRICT "-fp-speculation=strict")
 
-set (OPTREPORT0 "-qopt-report0")
-set (OPTREPORT5 "-qopt-report5")
+set (ARCH_CONSISTENCY "-fimf-arch-consistency=true")
 
+set (FTZ "-ftz")
+set (NO_PREC_DIV "-no-prec-div")
+set (USE_SVML "-fimf-use-svml=true ")
+
+set (IPO "-ipo")
+set (FMA "-fma")
+set (NO_FMA "-no-fma")
 set (FREAL8 "-r8")
 set (FINT8 "-i8")
 
+# ----------------------------------------------------------------------
+# Reports
+# ----------------------------------------------------------------------
+set (OPTREPORT0 "-qopt-report0")
+set (OPTREPORT5 "-qopt-report5")
+
+# ----------------------------------------------------------------------
+# Portability / source format
+# ----------------------------------------------------------------------
 set (PP    "-fpp")
-set (MISMATCH "")
 set (BIG_ENDIAN "-convert big_endian")
 set (LITTLE_ENDIAN "-convert little_endian")
 set (EXTENDED_SOURCE "-extend-source")
 set (FIXED_SOURCE "-fixed")
+set (NO_RANGE_CHECK "")
+
+# ----------------------------------------------------------------------
+# Warnings / diagnostics
+# ----------------------------------------------------------------------
 set (DISABLE_FIELD_WIDTH_WARNING "-diag-disable 8291")
 set (DISABLE_GLOBAL_NAME_WARNING "-diag-disable 5462")
-set (CRAY_POINTER "")
+set (DISABLE_10337 "-diag-disable 10337")   # fno-builtin warning
+set (DISABLE_10121 "-diag-disable 10121")   # fp-model override warning
+set (DISABLE_10448 "-diag-disable 10448")   # ifort deprecation remark
+set (DISABLE_LONG_LINE_LENGTH_WARNING "-diag-disable 5268")
+
+# Make an option to make things quiet during debug builds
+option (QUIET_DEBUG "Suppress excess compiler output during debug builds" OFF)
+if (QUIET_DEBUG)
+  set (WARN_UNUSED "")
+  set (SUPPRESS_COMMON_WARNINGS "${DISABLE_FIELD_WIDTH_WARNING} ${DISABLE_GLOBAL_NAME_WARNING} ${DISABLE_10337}")
+else ()
+  set (WARN_UNUSED "-warn unused")
+  set (SUPPRESS_COMMON_WARNINGS "${DISABLE_GLOBAL_NAME_WARNING} ${DISABLE_10337}")
+endif ()
+
+# ----------------------------------------------------------------------
+# Memory / alignment
+# ----------------------------------------------------------------------
 set (MCMODEL "-mcmodel medium -shared-intel")
 set (HEAPARRAYS "-heap-arrays 32")
 set (BYTERECLEN "-assume byterecl")
-set (ALIGNCOM "-align dcommons")
 set (TRACEBACK "-traceback")
 set (NOOLD_MAXMINLOC "-assume noold_maxminloc")
 set (REALLOC_LHS "-assume realloc_lhs")
-set (ARCH_CONSISTENCY "-fimf-arch-consistency=true")
-set (FTZ "-ftz")
-set (FMA "-fma")
-set (NO_FMA "-no-fma")
-set (ALIGN_ALL "-align all")
+set (ALIGNCOM "-align dcommons")
 set (NO_ALIAS "-fno-alias")
-set (USE_SVML "-fimf-use-svml=true")
-
-# Additional flags for better Standards compliance
-## Set the Standard to be Fortran 2018
-set (STANDARD_F18 "-stand f18")
-## Error out if you try to do if(integer)
-set (ERROR_IF_INTEGER "-diag-error 6188")
-## Error out if you try to set a logical to an integer
-set (ERROR_LOGICAL_SET_TO_INTEGER "-diag-error 6192")
-## Turn off warning #5268 (Extension to standard: The text exceeds right hand column allowed on the line.)
-set (DISABLE_LONG_LINE_LENGTH_WARNING "-diag-disable 5268")
-
-## Turn off ifort: warning #10337: option '-fno-builtin' disables '-imf*' option
-set (DISABLE_10337 "-diag-disable 10337")
-
-## Turn off ifort: command line warning #10121: overriding '-fp-model precise' with '-fp-model fast'
-set (DISABLE_10121 "-diag-disable 10121")
-
-## Turn off remark #10448 warning about ifort deprecation in late 2024
-set (DISABLE_10448 "-diag-disable=10448")
-
-set (NO_RANGE_CHECK "")
+set (ARRAY_ALIGN_32BYTE "-align array32byte")
+set (ARRAY_ALIGN_64BYTE "-align array64byte")
 
 cmake_host_system_information(RESULT proc_description QUERY PROCESSOR_DESCRIPTION)
 if (${proc_description} MATCHES "EPYC")
@@ -117,57 +139,52 @@ else ()
   message(FATAL_ERROR "Unknown processor. Please file an issue at https://github.com/GEOS-ESM/ESMA_cmake")
 endif ()
 
+# ----------------------------------------------------------------------
+# Defines
+# ----------------------------------------------------------------------
 add_definitions(-DHAVE_SHMEM)
 
-# Make an option to make things quiet during debug builds
-option (QUIET_DEBUG "Suppress excess compiler output during debug builds" OFF)
-if (QUIET_DEBUG)
-  set (WARN_UNUSED "")
-  set (SUPPRESS_COMMON_WARNINGS "${DISABLE_FIELD_WIDTH_WARNING} ${DISABLE_GLOBAL_NAME_WARNING} ${DISABLE_10337}")
-else ()
-  set (WARN_UNUSED "-warn unused")
-  set (SUPPRESS_COMMON_WARNINGS "${DISABLE_GLOBAL_NAME_WARNING} ${DISABLE_10337}")
-endif ()
+# ----------------------------------------------------------------------
+# Common flag bundles
+# ----------------------------------------------------------------------
+set (common_Fortran_flags "${TRACEBACK} ${REALLOC_LHS} ${OPTREPORT0} ${ALIGNCOM} ${NO_ALIAS}")
+set (common_Fortran_fpe_flags "${NOOLD_MAXMINLOC} ${DISABLE_10121} ${DISABLE_10448}")
 
-####################################################
-
-# Common Fortran Flags
-# --------------------
-set (common_Fortran_flags "${TRACEBACK} ${REALLOC_LHS} ${OPTREPORT0} ${ALIGN_ALL} ${NO_ALIAS}")
-set (common_Fortran_fpe_flags "${FTZ} ${NOOLD_MAXMINLOC} ${DISABLE_10121} ${DISABLE_10448}")
-
-# GEOS Debug
-# ----------
+# ----------------------------------------------------------------------
+# Build type specific bundles
+# ----------------------------------------------------------------------
+# Debug
 set (GEOS_Fortran_Debug_Flags "${DEBINFO} ${FOPT0} -debug -nolib-inline -fno-inline-functions -assume protect_parens,minus0 -prec-div -prec-sqrt -check all,noarg_temp_created -fp-stack-check ${WARN_UNUSED} -init=snan,arrays -save-temps")
 set (GEOS_Fortran_Debug_FPE_Flags "${FPE0} ${FP_MODEL_STRICT} ${FP_SPECULATION_STRICT} ${common_Fortran_fpe_flags} ${SUPPRESS_COMMON_WARNINGS}")
 
-# GEOS Safe
-# ----------------
-set (GEOS_Fortran_Safe_Flags "${FOPT2} ${DEBINFO}")
-set (GEOS_Fortran_Safe_FPE_Flags "${FPE1} ${FP_MODEL_PRECISE} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_STRICT} ${common_Fortran_fpe_flags}")
+# Strict (bitwise reproducible, IEEE-compliant)
+set (GEOS_Fortran_Strict_Flags "${FOPT2} ${DEBINFO}")
+set (GEOS_Fortran_Strict_FPE_Flags
+     "${FP_STRICT} ${FP_SPECULATION_STRICT} ${FPE0} -check uninit -prec-div -prec-sqrt -no-ftz ${common_Fortran_fpe_flags}") 
 
-# GEOS NoVectorize
-# ----------------
-set (GEOS_Fortran_NoVect_Flags "${FOPT3} ${DEBINFO}")
-set (GEOS_Fortran_NoVect_FPE_Flags "${FPE1} ${FP_MODEL_FAST1} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
+# NoVect (bitwise stable, no FMA)
+set (GEOS_Fortran_NoVect_Flags
+     "${FOPT3}")
+set (GEOS_Fortran_NoVect_FPE_Flags
+     "${FP_PRECISE} ${FP_SOURCE} ${FP_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FPE1} ${common_Fortran_fpe_flags}")
 
-# NOTE It was found that the Vectorizing Flags gave better performance with the same results in testing.
-#      But in case they are needed, we keep the older flags available
+# Vectorization with floating point exception trapping
+set (GEOS_Fortran_VectTrap_Flags
+     "${FOPT2} ${COREAVX2_FLAG} ${ARRAY_ALIGN_32BYTE}")
+set (GEOS_Fortran_VectTrap_FPE_Flags
+     "${FP_PRECISE} ${FP_SOURCE} ${FP_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FPE0} -check uninit ${common_Fortran_fpe_flags}")
 
-# GEOS Stock-Vect
-# ---------------
-set (GEOS_Fortran_StockVect_Flags "${FOPT3} ${DEBINFO} ${COREAVX2_FLAG} ${FMA} -align array32byte")
-set (GEOS_Fortran_StockVect_FPE_Flags "${FPE3} ${FP_MODEL_FAST} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${common_Fortran_fpe_flags}")
+# Vectorized
+set (GEOS_Fortran_Vect_Flags
+     "${FOPT3} ${COREAVX2_FLAG} ${ARRAY_ALIGN_32BYTE}")
+set (GEOS_Fortran_Vect_FPE_Flags
+     "${FP_FAST1} ${FP_SOURCE} ${FP_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${FPE1} ${common_Fortran_fpe_flags}")
 
-# GEOS Vectorize
-# ---------------
-set (GEOS_Fortran_Vect_Flags "${FOPT3} ${DEBINFO} ${COREAVX2_FLAG} -align array32byte")
-set (GEOS_Fortran_Vect_FPE_Flags "${FPE1} ${FP_MODEL_FAST1} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${NO_FMA} ${ARCH_CONSISTENCY} ${FP_SPECULATION_SAFE} ${common_Fortran_fpe_flags}")
-
-# GEOS Aggressive
-# ---------------
-set (GEOS_Fortran_Aggressive_Flags "${FOPT3} ${DEBINFO} ${COREAVX2_FLAG} -align array32byte")
-set (GEOS_Fortran_Aggressive_FPE_Flags "${FPE3} ${FP_MODEL_FAST2} ${FP_MODEL_SOURCE} ${FP_MODEL_CONSISTENT} ${FMA} ${FP_SPECULATION_FAST} ${USE_SVML} ${common_Fortran_fpe_flags}")
+# Aggressive (fast math, SVML)
+set (GEOS_Fortran_Aggressive_Flags
+     "${FOPT3} ${COREAVX2_FLAG} ${ARRAY_ALIGN_32BYTE}")
+set (GEOS_Fortran_Aggressive_FPE_Flags
+     "${FP_FAST2} ${FP_SOURCE} ${FP_CONSISTENT} ${FMA} ${USE_SVML} ${FPE3} ${common_Fortran_fpe_flags}")
 
 # Set Release flags
 # -----------------
@@ -176,3 +193,4 @@ set (GEOS_Fortran_Release_FPE_Flags "${GEOS_Fortran_Vect_FPE_Flags}")
 
 # Common variables for every compiler
 include(Generic_Fortran)
+

--- a/compiler/flags/LLVMFlang_Fortran.cmake
+++ b/compiler/flags/LLVMFlang_Fortran.cmake
@@ -76,7 +76,7 @@ set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 set (GEOS_Fortran_Release_Flags "${FOPT3} ${FLANG_TARGET_ARCH} ${DEBINFO}")
 set (GEOS_Fortran_Release_FPE_Flags "${common_Fortran_fpe_flags}")
 
-# Create a NoVectorize version for consistency. No difference from Release for GNU
+# Create a NoVectorize version for consistency. No difference from Release for Flang
 
 # GEOS NoVectorize
 # ----------------
@@ -85,13 +85,21 @@ set (GEOS_Fortran_NoVect_FPE_Flags "${GEOS_Fortran_Release_FPE_Flags}")
 
 # GEOS Vectorize
 # --------------
-
 # Until good options can be found, make vectorize equal common flags
 set (GEOS_Fortran_Vect_Flags ${GEOS_Fortran_Release_Flags})
 set (GEOS_Fortran_Vect_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
 
-set (GEOS_Fortran_Aggressive_Flags "${GEOS_Fortran_Release_Flags}")
-set (GEOS_Fortran_Aggressive_FPE_Flags "${GEOS_Fortran_Release_FPE_Flags}")
+# GEOS VectTrap
+# --------------
+# Until good options can be found, make vecttrap equal common flags
+set (GEOS_Fortran_VectTrap_Flags ${GEOS_Fortran_Release_Flags})
+set (GEOS_Fortran_VectTrap_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
+
+# GEOS Aggressive
+# ---------------
+# Until good options can be found, make vectorize equal common flags
+set (GEOS_Fortran_Aggressive_Flags ${GEOS_Fortran_Release_Flags})
+set (GEOS_Fortran_Aggressive_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
 
 # Common variables for every compiler
 include(Generic_Fortran)

--- a/compiler/flags/NAG_Fortran.cmake
+++ b/compiler/flags/NAG_Fortran.cmake
@@ -51,6 +51,12 @@ set (GEOS_Fortran_NoVect_FPE_Flags "${GEOS_Fortran_Release_FPE_Flags}")
 set (GEOS_Fortran_Vect_Flags ${GEOS_Fortran_Release_Flags})
 set (GEOS_Fortran_Vect_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
 
+# GEOS VectTrap
+# --------------
+# Until good options can be found, make vecttrap equal common flags
+set (GEOS_Fortran_VectTrap_Flags ${GEOS_Fortran_Release_Flags})
+set (GEOS_Fortran_VectTrap_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
+
 # GEOS Aggressive
 # ---------------
 # Until good options can be found, make vectorize equal common flags

--- a/compiler/flags/NVHPC_Fortran.cmake
+++ b/compiler/flags/NVHPC_Fortran.cmake
@@ -53,6 +53,12 @@ set (GEOS_Fortran_NoVect_FPE_Flags "${GEOS_Fortran_Release_FPE_Flags}")
 set (GEOS_Fortran_Vect_Flags ${GEOS_Fortran_Release_Flags})
 set (GEOS_Fortran_Vect_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
 
+# GEOS VectTrap
+# --------------
+# Until good options can be found, make vecttrap equal common flags
+set (GEOS_Fortran_VectTrap_Flags ${GEOS_Fortran_Release_Flags})
+set (GEOS_Fortran_VectTrap_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
+
 # GEOS Aggressive
 # ---------------
 # Until good options can be found, make vectorize equal common flags


### PR DESCRIPTION
There are new VectTrap flags from @wmputman that are used with ifort. We also add stubs for all the other compilers.

The Intel Fortran flags did change and are most likely non-zero-diff as well (came in with other Physics changes)