### PR TITLE
v4: Try and find Python more consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.26.0] - 2025-10-09
+
+### Changed
+
+- Updated the Python and Python3 detection better find f2py and f2py3 given the found Python executable
+
 ## [4.25.0] - 2025-10-02
 
 ### Added

--- a/python/f2py/FindF2PY.cmake
+++ b/python/f2py/FindF2PY.cmake
@@ -38,15 +38,16 @@
 
 ## Find the directory where the Python_EXECUTABLE is located
 message(DEBUG "[F2PY]: Searching for f2py executable associated with Python_EXECUTABLE: ${Python_EXECUTABLE}")
-get_filename_component(PYTHON_EXECUTABLE_DIR ${Python_EXECUTABLE} DIRECTORY)
-message(DEBUG "[F2PY]: Python executable directory: ${PYTHON_EXECUTABLE_DIR}")
+get_filename_component(Python_EXECUTABLE_DIR ${Python_EXECUTABLE} DIRECTORY)
+message(DEBUG "[F2PY]: Python executable directory: ${Python_EXECUTABLE_DIR}")
 
 find_program(F2PY_EXECUTABLE
-  NAMES "f2py"
-        "f2py${Python_VERSION_MAJOR}"
+  NAMES "f2py${Python_VERSION_MAJOR}"
         "f2py${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"
         "f2py-${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"
-  PATHS ${PYTHON_EXECUTABLE_DIR}
+        "f2py"
+  PATHS ${Python_EXECUTABLE_DIR}
+  HINTS ${Python_EXECUTABLE_DIR}
 )
 
 message(DEBUG "[F2PY]: Found f2py executable: ${F2PY_EXECUTABLE}")
@@ -58,7 +59,7 @@ message(DEBUG "[F2PY]: f2py executable directory: ${F2PY_EXECUTABLE_DIR}")
 
 # Now we issue a WARNING. We can't do more than that because of things like Spack
 # where f2py will be in a different location than python.
-if (NOT "${F2PY_EXECUTABLE_DIR}" STREQUAL "${PYTHON_EXECUTABLE_DIR}")
+if (NOT "${F2PY_EXECUTABLE_DIR}" STREQUAL "${Python_EXECUTABLE_DIR}")
   message(WARNING
     "[F2PY]: The f2py executable [${F2PY_EXECUTABLE}] found is not the one associated with the Python_EXECUTABLE [${Python_EXECUTABLE}].\n"
     "Please check your Python environment if this is not expected (for example, not a Spack install) or build with -DUSE_F2PY=OFF.")
@@ -102,6 +103,7 @@ if(F2PY_EXECUTABLE)
 
      set(F2PY_FCOMPILER ${_fcompiler} CACHE STRING
        "F2PY: Fortran compiler type by vendor" FORCE)
+     message(DEBUG "[F2PY]: Fortran compiler type: ${F2PY3_FCOMPILER}")
 
      if(NOT F2PY_FCOMPILER)
        message(FATAL_ERROR "[F2PY]: Could not determine Fortran compiler type. ")

--- a/python/f2py/try_f2py_compile.cmake
+++ b/python/f2py/try_f2py_compile.cmake
@@ -19,8 +19,8 @@ macro (try_f2py_compile file var)
    else ()
      set(MESON_F2PY_FCOMPILER "${CMAKE_Fortran_COMPILER}")
    endif ()
-   message(DEBUG "MESON_F2PY_FCOMPILER is set to ${MESON_F2PY_FCOMPILER}")
-   message(DEBUG "F2PY_COMPILER is set to ${F2PY_COMPILER}")
+   message(DEBUG "[F2PY] MESON_F2PY_FCOMPILER is set to ${MESON_F2PY_FCOMPILER}")
+   message(DEBUG "[F2PY] F2PY_COMPILER is set to ${F2PY_COMPILER}")
    # hack for Macs. If the C compiler is clang and we are on Apple,
    # we need to set the CC environment to /usr/bin/clang
    if(APPLE AND CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
@@ -29,11 +29,11 @@ macro (try_f2py_compile file var)
    else()
      set(MESON_CCOMPILER "${CMAKE_C_COMPILER}")
    endif()
-   message(DEBUG "MESON_CCOMPILER is set to ${MESON_CCOMPILER}")
+   message(DEBUG "[F2PY] MESON_CCOMPILER is set to ${MESON_CCOMPILER}")
    list(APPEND ENV_LIST FC=${MESON_F2PY_FCOMPILER})
    list(APPEND ENV_LIST CC=${MESON_CCOMPILER})
    list(APPEND ENV_LIST TMPDIR=${_f2py_check_bindir})
-   message(DEBUG "ENV_LIST is set to ${ENV_LIST}")
+   message(DEBUG "[F2PY] ENV_LIST is set to ${ENV_LIST}")
    execute_process(
      COMMAND cmake -E env ${ENV_LIST} ${F2PY_EXECUTABLE} -m test_ -c ${file} --fcompiler=${F2PY_FCOMPILER}
      WORKING_DIRECTORY ${_f2py_check_bindir}
@@ -44,6 +44,7 @@ macro (try_f2py_compile file var)
 
    if (result EQUAL 0)
       file(GLOB F2PY_TEST_OUTPUT_FILE ${_f2py_check_bindir}/*.so)
+      message(DEBUG "[F2PY] F2PY_TEST_OUTPUT_FILE is ${F2PY_TEST_OUTPUT_FILE}")
 
       get_filename_component(F2PY_FOUND_EXTENSION ${F2PY_TEST_OUTPUT_FILE} EXT)
 

--- a/python/f2py3/FindF2PY3.cmake
+++ b/python/f2py3/FindF2PY3.cmake
@@ -38,15 +38,16 @@
 
 ## Find the directory where the Python3_EXECUTABLE is located
 message(DEBUG "[F2PY3]: Searching for f2py3 executable associated with Python3_EXECUTABLE: ${Python3_EXECUTABLE}")
-get_filename_component(PYTHON3_EXECUTABLE_DIR ${Python3_EXECUTABLE} DIRECTORY)
-message(DEBUG "[F2PY3]: Python3 executable directory: ${PYTHON3_EXECUTABLE_DIR}")
+get_filename_component(Python3_EXECUTABLE_DIR ${Python3_EXECUTABLE} DIRECTORY)
+message(DEBUG "[F2PY3]: Python3 executable directory: ${Python3_EXECUTABLE_DIR}")
 
 find_program(F2PY3_EXECUTABLE
-  NAMES "f2py"
-        "f2py${Python3_VERSION_MAJOR}"
+  NAMES "f2py${Python3_VERSION_MAJOR}"
         "f2py${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
         "f2py-${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
-  PATHS ${PYTHON3_EXECUTABLE_DIR}
+        "f2py"
+  PATHS ${Python3_EXECUTABLE_DIR}
+  HINTS ${Python3_EXECUTABLE_DIR}
 )
 
 message(DEBUG "[F2PY3]: Found f2py3 executable: ${F2PY3_EXECUTABLE}")
@@ -58,7 +59,7 @@ message(DEBUG "[F2PY3]: f2py3 executable directory: ${F2PY3_EXECUTABLE_DIR}")
 
 # Now we issue a WARNING. We can't do more than that because of things like Spack
 # where f2py will be in a different location than python.
-if (NOT "${F2PY3_EXECUTABLE_DIR}" STREQUAL "${PYTHON3_EXECUTABLE_DIR}")
+if (NOT "${F2PY3_EXECUTABLE_DIR}" STREQUAL "${Python3_EXECUTABLE_DIR}")
   message(WARNING
     "[F2PY3]: The f2py3 executable [${F2PY3_EXECUTABLE}] found is not the one associated with the Python3_EXECUTABLE [${Python3_EXECUTABLE}].\n"
     "Please check your Python3 environment if this is not expected (for example, not a Spack install) or build with -DUSE_F2PY=OFF.")
@@ -102,6 +103,7 @@ if(F2PY3_EXECUTABLE)
 
      set(F2PY3_FCOMPILER ${_fcompiler} CACHE STRING
        "F2PY3: Fortran compiler type by vendor" FORCE)
+     message(DEBUG "[F2PY3]: Fortran compiler type: ${F2PY3_FCOMPILER}")
 
      if(NOT F2PY3_FCOMPILER)
        message(FATAL_ERROR "[F2PY3]: Could not determine Fortran compiler type. ")

--- a/python/f2py3/try_f2py3_compile.cmake
+++ b/python/f2py3/try_f2py3_compile.cmake
@@ -19,8 +19,8 @@ macro (try_f2py3_compile file var)
    else ()
      set(MESON_F2PY3_FCOMPILER "${CMAKE_Fortran_COMPILER}")
    endif ()
-   message(DEBUG "MESON_F2PY3_FCOMPILER is set to ${MESON_F2PY3_FCOMPILER}")
-   message(DEBUG "F2PY3_COMPILER is set to ${F2PY3_COMPILER}")
+   message(DEBUG "[F2PY3] MESON_F2PY3_FCOMPILER is set to ${MESON_F2PY3_FCOMPILER}")
+   message(DEBUG "[F2PY3] F2PY3_COMPILER is set to ${F2PY3_COMPILER}")
    # hack for Macs. If the C compiler is clang and we are on Apple,
    # we need to set the CC environment to /usr/bin/clang
    if(APPLE AND CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
@@ -29,11 +29,11 @@ macro (try_f2py3_compile file var)
    else()
      set(MESON_CCOMPILER "${CMAKE_C_COMPILER}")
    endif()
-   message(DEBUG "MESON_CCOMPILER is set to ${MESON_CCOMPILER}")
+   message(DEBUG "[F2PY3] MESON_CCOMPILER is set to ${MESON_CCOMPILER}")
    list(APPEND ENV_LIST FC=${MESON_F2PY3_FCOMPILER})
    list(APPEND ENV_LIST CC=${MESON_CCOMPILER})
    list(APPEND ENV_LIST TMPDIR=${_f2py3_check_bindir})
-   message(DEBUG "ENV_LIST is set to ${ENV_LIST}")
+   message(DEBUG "[F2PY3] ENV_LIST is set to ${ENV_LIST}")
    execute_process(
      COMMAND cmake -E env ${ENV_LIST} ${F2PY3_EXECUTABLE} -m test_ -c ${file} --fcompiler=${F2PY3_FCOMPILER}
      WORKING_DIRECTORY ${_f2py3_check_bindir}
@@ -44,6 +44,7 @@ macro (try_f2py3_compile file var)
 
    if (result EQUAL 0)
       file(GLOB F2PY3_TEST_OUTPUT_FILE ${_f2py3_check_bindir}/*.so)
+      message(DEBUG "[F2PY3] F2PY3_TEST_OUTPUT_FILE is ${F2PY3_TEST_OUTPUT_FILE}")
 
       get_filename_component(F2PY3_FOUND_EXTENSION ${F2PY3_TEST_OUTPUT_FILE} EXT)
 


### PR DESCRIPTION
This is an attempt to have ESMA_cmake better find the `f2py` we want. Some users have their own Python stack which can cause issues.

NOTE: For the full use of this with, say, GEOSpyD, it requires the use of `Python3_ROOT_DIR` and `Python_ROOT_DIR` to be set correctly. CMake then seems to be able to find things as expected.