### PR TITLE
v5: Update GNU Release Flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.28.0] - 2025-10-17
+
+### Changed
+
+- Update GNU flags to not do `-ffpe-trap` when building as `Release`
+  - This was causing (spurious??) issues with some GEOSgcm runs with GCC 15
+
 ## [4.27.0] - 2025-10-14
 
 ### Changed

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -157,11 +157,11 @@ add_definitions(-D__GFORTRAN__)
 # Common Fortran Flags
 # --------------------
 set (common_Fortran_flags "-ffree-line-length-none ${NO_RANGE_CHECK} -Wno-missing-include-dirs ${TRACEBACK} ${UNUSED_DUMMY}" )
-set (common_Fortran_fpe_flags "-ffpe-trap=zero,overflow ${TRACEBACK} ${MISMATCH} ${ALLOW_BOZ}")
+set (common_Fortran_fpe_flags "${TRACEBACK} ${MISMATCH} ${ALLOW_BOZ}")
 
 # GEOS Debug
 # ----------
-set (GEOS_Fortran_Debug_Flags "${FOPT0} ${DEBINFO} -fcheck=all,no-array-temps -finit-real=snan -save-temps")
+set (GEOS_Fortran_Debug_Flags "${FOPT0} ${DEBINFO} -ffpe-trap=zero,overflow -fcheck=all,no-array-temps -finit-real=snan -save-temps")
 set (GEOS_Fortran_Debug_FPE_Flags "${common_Fortran_fpe_flags}")
 
 # GEOS Release


### PR DESCRIPTION
This PR updates the GNU flags for v4. For some reason the use of `--ffpe-trap` in our Release flags was causing crashes. Even though the *same* use with Debug flags didn't. So the optimizer is doing something weird.

Until this can be investigated further, for now we just remove this flag so GCC 15 testing can continue.