### PR TITLE
v4: Add new Coverage build type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.37.0] - 2026-04-13
+
+### Added
+
+- Added new `Coverage` build type for use in code coverage testing. Currently only supports GNU.
+
 ## [4.36.0] - 2026-03-31
 
 ### Fixed

--- a/compiler/esma_compiler.cmake
+++ b/compiler/esma_compiler.cmake
@@ -10,7 +10,7 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/checks")
 include(check_fortran_support)
 
 ## We only allow for three CMake Build Types
-set(ALLOWED_BUILD_TYPES "Debug" "Release" "Aggressive" "VectTrap")
+set(ALLOWED_BUILD_TYPES "Debug" "Release" "Aggressive" "VectTrap" "Coverage")
 if(NOT CMAKE_BUILD_TYPE IN_LIST ALLOWED_BUILD_TYPES)
   string(REPLACE ";" ", " ALLOWED_BUILD_TYPES_STRING "${ALLOWED_BUILD_TYPES}")
   message(FATAL_ERROR "The only allowed CMAKE_BUILD_TYPE are: ${ALLOWED_BUILD_TYPES_STRING}")

--- a/compiler/flags/GNU_Fortran.cmake
+++ b/compiler/flags/GNU_Fortran.cmake
@@ -191,6 +191,16 @@ set (GEOS_Fortran_Vect_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
 set (GEOS_Fortran_VectTrap_Flags ${GEOS_Fortran_Release_Flags})
 set (GEOS_Fortran_VectTrap_FPE_Flags ${GEOS_Fortran_Release_FPE_Flags})
 
+# GEOS Coverage
+# -------------
+# Intended for use with gcov/lcov.  Requires -O0 and --coverage (which expands
+# to -fprofile-arcs -ftest-coverage for both compile and link).
+# We intentionally skip -ffpe-trap and array checks (-fcheck) so that the
+# instrumented code does not abort on benign floating-point exceptions during
+# a coverage run.
+set (GEOS_Fortran_Coverage_Flags "${FOPT0} ${DEBINFO} --coverage")
+set (GEOS_Fortran_Coverage_FPE_Flags "${common_Fortran_fpe_flags}")
+
 # GEOS Aggressive
 # ---------------
 # NOTE: gfortran does get a benefit from vectorization, but the resulting code

--- a/compiler/flags/Generic_Fortran.cmake
+++ b/compiler/flags/Generic_Fortran.cmake
@@ -9,3 +9,15 @@ set (CMAKE_Fortran_FLAGS_DEBUG      "${GEOS_Fortran_FLAGS_DEBUG}"      CACHE STR
 set (CMAKE_Fortran_FLAGS_RELEASE    "${GEOS_Fortran_FLAGS_RELEASE}"    CACHE STRING "Release Fortran flags"    FORCE )
 set (CMAKE_Fortran_FLAGS_VECTTRAP   "${GEOS_Fortran_FLAGS_VECTTRAP}"   CACHE STRING "VectTrap Fortran flags"   FORCE )
 set (CMAKE_Fortran_FLAGS_AGGRESSIVE "${GEOS_Fortran_FLAGS_AGGRESSIVE}" CACHE STRING "Aggressive Fortran flags" FORCE )
+
+# Coverage build type: gcov/lcov instrumentation.
+# --coverage is a GCC-specific flag (shorthand for -fprofile-arcs -ftest-coverage).
+# Only set the Coverage flags and linker flags when using GNU compilers; other
+# compilers (Intel ifort/ifx, NAG, NVHPC) do not support --coverage and would
+# produce a link error if these flags were applied.
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  set (GEOS_Fortran_FLAGS_COVERAGE "${GEOS_Fortran_Coverage_Flags} ${common_Fortran_flags} ${GEOS_Fortran_Coverage_FPE_Flags} ${ALIGNCOM}")
+  set (CMAKE_Fortran_FLAGS_COVERAGE   "${GEOS_Fortran_FLAGS_COVERAGE}" CACHE STRING "Coverage Fortran flags" FORCE)
+  set (CMAKE_EXE_LINKER_FLAGS_COVERAGE    "--coverage" CACHE STRING "Coverage linker flags for executables" FORCE)
+  set (CMAKE_SHARED_LINKER_FLAGS_COVERAGE "--coverage" CACHE STRING "Coverage linker flags for shared libs"  FORCE)
+endif()

--- a/operating_system/osx_extras.cmake
+++ b/operating_system/osx_extras.cmake
@@ -68,22 +68,22 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Flang" OR CMAKE_Fortran_COMPILER_ID MATCHE
 endif()
 
 # 6) Suppress duplicate rpath/library warnings that arise only with the
-# clang/clang++/gfortran toolchain on macOS.  gfortran injects its Cellar
+# clang/clang++/gfortran toolchain on macOS. gfortran injects its Cellar
 # lib directories as implicit link paths/rpaths; those get accumulated
 # multiple times via ESMF and Baselibs transitive dependencies, producing
-# noise on every link.  These are upstream issues, not MAPL bugs.
+# noise on every link. These are upstream issues, not MAPL bugs.
 #
 # Not needed (and not applied) when using nagfor, which has its own runtime
 # and does not inject gfortran Cellar paths.
 #
-#   -Wl,-w                           suppresses all ld warnings (duplicate
-#                                    rpath, missing search paths from the
-#                                    gfortran 15.2.0 vs 15.2.0_1 Cellar mismatch)
-#   -Wl,-no_warn_duplicate_libraries suppresses "ignoring duplicate libraries"
+# -Wl,-w suppresses all ld warnings (duplicate
+#         rpath, missing search paths from the
+#         gfortran 15.2.0 vs 15.2.0_1 Cellar mismatch)
+# -Wl,-no_warn_duplicate_libraries suppresses "ignoring duplicate libraries"
 #
 # Both flags are Apple ld (ld-prime/ld64) specific.
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-  set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS}    -Wl,-w -Wl,-no_warn_duplicate_libraries")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-w -Wl,-no_warn_duplicate_libraries")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-w -Wl,-no_warn_duplicate_libraries")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-w -Wl,-no_warn_duplicate_libraries")
 endif()


### PR DESCRIPTION
This PR adds a new `Coverage` build type for code coverage testing. Currently on GNU supported.