### PR TITLE
v5: Fix NAG Fortran build on macOS for GEOSldas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- changed NAG_Fortran so that some applications like GEOSldas can be built on MacOS 
+
 ### Deprecated
 
 ## [5.9.0] - 2026-04-13

--- a/compiler/flags/NAG_Fortran.cmake
+++ b/compiler/flags/NAG_Fortran.cmake
@@ -6,7 +6,7 @@ set (FREAL8 "-r8")
 set (FINT8 "-i8")
 set (PP    "-fpp")
 set (DUSTY "-dusty")
-set (MISMATCH "-wmismatch=QSORTL,QSORTS,MPI_Recv,MPI_Send,MPI_Irecv,MPI_BCast,MPI_Allgather,MPI_Allgatherv,MPI_Allreduce,MPI_Scatterv,MPI_Gatherv,MPI_Sendrecv,MPI_File_write,MPI_File_read,MPI_File_Read_at_all,MPI_File_write_at_all,ESMF_UserCompSetInternalState,ESMF_UserCompGetInternalState")
+set (MISMATCH "-wmismatch=QSORTL,QSORTS,MPI_Recv,MPI_Send,MPI_Irecv,MPI_BCast,MPI_Gather,MPI_Allgather,MPI_Allgatherv,MPI_Allreduce,MPI_Scatter,MPI_Scatterv,MPI_Gatherv,MPI_Sendrecv,MPI_Alltoallv,MPI_File_write,MPI_File_read,MPI_File_Read_at_all,MPI_File_write_at_all,ESMF_UserCompSetInternalState,ESMF_UserCompGetInternalState")
 set (DISABLE_FIELD_WIDTH_WARNING)
 set (CRAY_POINTER "")
 set (EXTENDED_SOURCE "-132 -w=x95" )
@@ -19,13 +19,26 @@ set (QUIET "-quiet")
 
 if (APPLE)
   option (ESMF_HAS_ACHAR_BUG "ESMF Compatibility issue" OFF)
+  # NAG Fortran doesn't understand Apple's -F framework flags
+  # Tell CMake to use -I for all include directories (including frameworks) for Fortran
+  set(CMAKE_INCLUDE_FLAG_Fortran "-I")
+  set(CMAKE_INCLUDE_SYSTEM_FLAG_Fortran "-I")
+  # Tell CMake not to add framework directories to Fortran implicit includes
+  set(CMAKE_Fortran_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES "" CACHE STRING "")
 endif ()
 
 ####################################################
 
 # Common Fortran Flags
 # --------------------
-set (common_Fortran_flags "${F2018} ${MISMATCH} ${QUIET}")
+# On macOS, CMake may add -F framework flags that NAG doesn't understand
+# We use -w=uep to suppress the specific unrecognised option error
+if (APPLE)
+  set (IGNORE_UNKNOWN_FLAGS "-w=uep")
+else()
+  set (IGNORE_UNKNOWN_FLAGS "")
+endif()
+set (common_Fortran_flags "${F2018} ${MISMATCH} ${QUIET} ${IGNORE_UNKNOWN_FLAGS}")
 set (common_Fortran_fpe_flags "")
 
 # GEOS Debug

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -98,10 +98,13 @@ if (Baselibs_FOUND)
 
   # Changes in Baselibs mean on Darwin we need to capture three
   # Framework Libraries needed to link with Curl (so netCDF needs them)
+  # On macOS, use framework names directly instead of find_library to avoid
+  # CMake adding framework paths to Fortran compiler flags
   if (APPLE)
-    find_library(FWSystemConfiguration NAMES SystemConfiguration)
-    find_library(FWCoreFoundation      NAMES CoreFoundation)
-    find_library(FWSecurity            NAMES Security)
+    # Use framework names directly - linker will find them automatically
+    set(FWSystemConfiguration "-framework SystemConfiguration")
+    set(FWCoreFoundation "-framework CoreFoundation")
+    set(FWSecurity "-framework Security")
   endif ()
 
   add_definitions(-DHAS_NETCDF4)


### PR DESCRIPTION
This commit enables successful compilation of GEOSldas with NAG Fortran compiler on macOS by addressing three critical issues:

1. NAG_Fortran.cmake (line 9):
   - Add MPI_Gather, MPI_Scatter, MPI_Alltoallv to MISMATCH flag
   - Fixes MPI type mismatch errors where different data types are passed to the same MPI function in different call sites

2. NAG_Fortran.cmake (lines 20-28):
   - Configure CMake to use -I flag for Fortran includes
   - Clear CMAKE_Fortran_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES
   - Prevents CMake from adding -F framework flags that NAG doesn't support
   - Fixes Fortran include path generation issues

3. NAG_Fortran.cmake (lines 32-41):
   - Add -w=uep flag to suppress unrecognized option errors on macOS
   - Handles any remaining framework-related warnings gracefully

4. FindBaselibs.cmake (lines 99-108):
   - Replace find_library() calls with direct framework names
   - Changes: find_library(FWSecurity NAMES Security) to: set(FWSecurity "-framework Security")
   - Prevents CMake from adding framework directories to Fortran include paths, which causes compilation errors with NAG

Without these changes, NAG Fortran fails to compile GEOSldas on macOS due to:
- Unrecognized -F framework flags in Fortran compiler invocations
- Malformed include paths missing -I separators
- MPI function type mismatch errors

Tested on: macOS with NAG Fortran 7.2.43, OpenMPI 5.0.10rc2, Baselibs 9.9.0
Build result: 100% successful, all executables built