### PR TITLE
v4: Use copy_if_different for submodules

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,4 +36,5 @@ jobs:
     with:
       fixture-repo: GEOS-ESM/GEOSgcm
       fixture-ref: feature/sdrabenh/gcm_v12
+      load-fms: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.38.0] - 2026-05-19
+
+### Changed
+
+- Use `copy_if_different` in `esma_add_fortran_submodules.cmake` to prevent unnecessary copying of submodule files when they haven't changed.
+
 ## [4.37.0] - 2026-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use `copy_if_different` in `esma_add_fortran_submodules.cmake` to prevent unnecessary copying of submodule files when they haven't changed.
+- Update NVHPC flags for ng compiler testing
 
 ## [4.37.0] - 2026-04-13
 

--- a/compiler/flags/NVHPC_Fortran.cmake
+++ b/compiler/flags/NVHPC_Fortran.cmake
@@ -18,15 +18,12 @@ set (TRACEBACK "-traceback")
 
 ####################################################
 
-add_definitions(-D__PGI) # Needed for LANL CICE
-add_definitions(-D__PGI) # Needed for LANL CICE
-
-set(CMAKE_EXE_LINKER_FLAGS "-pgc++libs -tp=px-64" CACHE INTERNAL "" FORCE)
+#set(CMAKE_EXE_LINKER_FLAGS "-pgc++libs -tp=px-64" CACHE INTERNAL "" FORCE)
 
 # Common Fortran Flags
 # --------------------
 set (common_Fortran_flags "${BACKSLASH_STRING}")
-set (common_Fortran_fpe_flags "-Ktrap=fp -tp=px-64")
+set (common_Fortran_fpe_flags "-Ktrap=fp")
 
 # GEOS Debug
 # ----------

--- a/esma_support/esma_add_fortran_submodules.cmake
+++ b/esma_support/esma_add_fortran_submodules.cmake
@@ -12,16 +12,16 @@ function(esma_add_fortran_submodules)
 
   foreach(file ${ARG_SOURCES})
 
-    set(input ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_SUBDIRECTORY}/${file})
+    set(input  ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_SUBDIRECTORY}/${file})
     set(output ${CMAKE_CURRENT_BINARY_DIR}/${ARG_SUBDIRECTORY}_SMOD_${file})
     set(esma_internal "esma_internal_${ARG_SUBDIRECTORY}_SMOD_${file}")
 
     add_custom_command(
       OUTPUT ${output}
-      COMMAND ${CMAKE_COMMAND} -E copy ${input} ${output}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${input} ${output}
       DEPENDS ${input}
     )
-    add_custom_target(${esma_internal}  DEPENDS ${output})
+    add_custom_target(${esma_internal} DEPENDS ${output})
 
     set_property(SOURCE ${output} TARGET_DIRECTORY ${ARG_TARGET} PROPERTY GENERATED 1)
     add_dependencies(${ARG_TARGET} ${esma_internal})


### PR DESCRIPTION
This PR updates `esma_support/esma_add_fortran_submodules.cmake` to use `copy_if_different`. This can hopefully prevent unneeded recompiles of submodules.