### PR TITLE
v4: update ifx flags and changelog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v8.18.0
+#baselibs_version: &baselibs_version v8.32.0
 #bcs_version: &bcs_version v12.0.0
 
 orbs:
@@ -17,17 +17,11 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              # ifx does not compile FMS 2024, so we skip it for now
-              #compiler: [gfortran, ifort, ifx]
               compiler: [gfortran, ifort]
-          #baselibs_version: *baselibs_version
+          fail_fast: true
           repo: GEOSgcm
           checkout_fixture: true
-          # V12 code uses a special branch for now.
-          fixture_branch: feature/sdrabenh/gcm_v12
-          develop_repos: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared FVdycoreCubed_GridComp fvdycore"
-          # We comment out this as it will "undo" the fixture_branch
-          #mepodevelop: true
+          mepodevelop: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
 
       # Run AMIP GCM (1 hour, no ExtData)
@@ -37,9 +31,8 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              # ifx does not compile FMS 2024, so we skip it for now
-              #compiler: [gfortran, ifort, ifx]
               compiler: [gfortran, ifort]
+          fail_fast: true
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          fail_fast: true
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true
@@ -32,7 +31,6 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          fail_fast: true
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   build_gcm:
     strategy:
+      fail-fast: false
       matrix:
         compiler: [ifort, gfortran-15, ifx]
         build-type: [Debug]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,14 +19,13 @@ jobs:
   build_gcm:
     strategy:
       matrix:
-        compiler: [ifort, gfortran-14, gfortran-15]
+        compiler: [ifort, gfortran-15]
         build-type: [Debug]
     uses: GEOS-ESM/CI-workflows/.github/workflows/geosgcm_build_tests.yml@project/geosgcm
     with:
       compiler: ${{ matrix.compiler }}
       cmake-build-type: ${{ matrix.build-type }}
       fixture-repo: GEOS-ESM/GEOSgcm
-      fixture-ref: feature/sdrabenh/gcm_v12
 
   spack_build:
     uses: GEOS-ESM/CI-workflows/.github/workflows/spack_gcc_build.yml@project/geosgcm
@@ -35,6 +34,5 @@ jobs:
       BUILDCACHE_TOKEN: ${{ secrets.BUILDCACHE_TOKEN }}
     with:
       fixture-repo: GEOS-ESM/GEOSgcm
-      fixture-ref: feature/sdrabenh/gcm_v12
       load-fms: true
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
   build_gcm:
     strategy:
       matrix:
-        compiler: [ifort, gfortran-15]
+        compiler: [ifort, gfortran-15, ifx]
         build-type: [Debug]
     uses: GEOS-ESM/CI-workflows/.github/workflows/geosgcm_build_tests.yml@project/geosgcm
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.39.0] - 2026-06-04
 
-### Fixed
+### Changed
 
 - Update IntelLLVM Fortran flags to suppress common warnings and remove the redundant `-fp-speculation=safe` flag from `GEOS_Fortran_Vect_FPE_Flags`, which triggers warning #5425 under strict floating-point mode.
+- Update CI now that v12 code is in GEOSgcm main
 
 ## [4.38.0] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [4.39.0] - 2026-06-04
+
+### Fixed
+
+- Update IntelLLVM Fortran flags to suppress common warnings and remove the redundant `-fp-speculation=safe` flag from `GEOS_Fortran_Vect_FPE_Flags`, which triggers warning #5425 under strict floating-point mode.
+
 ## [4.38.0] - 2026-05-19
 
 ### Changed
@@ -1300,4 +1306,3 @@ NOTE This release of ESMA Cmake is not backwardly compatible to the 1.x series.
 ### Fixed
 
 - Fix cmake autodetect when embedded.
-

--- a/compiler/flags/IntelLLVM_Fortran.cmake
+++ b/compiler/flags/IntelLLVM_Fortran.cmake
@@ -105,8 +105,6 @@ set (NO_RANGE_CHECK "")
 set (DISABLE_FIELD_WIDTH_WARNING "-diag-disable 8291")
 set (DISABLE_GLOBAL_NAME_WARNING "-diag-disable 5462")
 set (DISABLE_10337 "-diag-disable 10337")   # fno-builtin warning
-set (DISABLE_10121 "-diag-disable 10121")   # fp-model override warning
-set (DISABLE_10448 "-diag-disable 10448")   # ifort deprecation remark
 set (DISABLE_LONG_LINE_LENGTH_WARNING "-diag-disable 5268")
 
 # Make an option to make things quiet during debug builds
@@ -173,7 +171,7 @@ add_definitions(-DHAVE_SHMEM)
 # Common flag bundles
 # ----------------------------------------------------------------------
 set (common_Fortran_flags "${TRACEBACK} ${REALLOC_LHS} ${OPTREPORT0} ${ALIGN_ALL} ${NO_ALIAS} ${PP}")
-set (common_Fortran_fpe_flags "${FTZ} ${NOOLD_MAXMINLOC}")
+set (common_Fortran_fpe_flags "${FTZ} ${NOOLD_MAXMINLOC} ${SUPPRESS_COMMON_WARNINGS}")
 
 # ----------------------------------------------------------------------
 # Build type specific bundles
@@ -205,10 +203,15 @@ set (GEOS_Fortran_VectTrap_FPE_Flags
 # currently pass layout regression reliably with ifx 2025.2 and 2025.3. Note:
 # this includes using flags much like our ifort ones with the (now working)
 # -fp-speculation=safe and -fp-speculation=strict options.
+#
+# We used to use -fp-speculation=safe here but ifx throws:
+#   warning #5425: Qualifier 'fp-speculation' conflicts with floating-point mode and will be ignored
+#
+# Testing shows it is zero-diff without the flag, so we remove it to keep noise down
 set (GEOS_Fortran_Vect_Flags
   "${FOPT3} ${MARCH_FLAG} ${ARRAY_ALIGN_32BYTE} -prec-div -assume protect_parens")
 set (GEOS_Fortran_Vect_FPE_Flags
-  "${FP_STRICT} ${NO_FMA} ${FP_SPECULATION_SAFE} ${FPE1} ${common_Fortran_fpe_flags}")
+  "${FP_STRICT} ${NO_FMA} ${FPE1} ${common_Fortran_fpe_flags}")
 
 # Aggressive (fast math, SVML)
 set (GEOS_Fortran_Aggressive_Flags


### PR DESCRIPTION
Update IntelLLVM Fortran flags to suppress common warnings and remove the redundant `-fp-speculation=safe` flag. 

We also update the CI now that GEOSgcm main is essentially v12-based.