### PR TITLE
v4: Add esma_sync_data CMake macro and script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `esma_sync_data()` CMake macro and build-time helper script to support build-time synchronization of data from AWS S3 buckets using temporary AWS credentials.
+
 ### Changed
 
 ### Deprecated

--- a/esma_support/esma_support.cmake
+++ b/esma_support/esma_support.cmake
@@ -1,15 +1,16 @@
 # CMake code that supports ESMA
 
-include (esma_check_if_debug)
-include (esma_set_this)
-include (esma_add_subdirectories)
-include (esma_mepo_style)
-include (esma_add_library)
-include (esma_generate_automatic_code)
-include (esma_create_stub_component)
-include (esma_fortran_generator_list)
-include (esma_add_fortran_submodules)
-include (esma_mepo_status)
+include(esma_check_if_debug)
+include(esma_set_this)
+include(esma_add_subdirectories)
+include(esma_mepo_style)
+include(esma_add_library)
+include(esma_generate_automatic_code)
+include(esma_create_stub_component)
+include(esma_fortran_generator_list)
+include(esma_add_fortran_submodules)
+include(esma_mepo_status)
+include(esma_sync_data)
 
 # Testing
-include (esma_enable_tests)
+include(esma_enable_tests)

--- a/esma_support/esma_sync_data.cmake
+++ b/esma_support/esma_sync_data.cmake
@@ -1,0 +1,138 @@
+# esma_sync_data.cmake
+#
+# Define build-time data sync targets.
+#
+# Example:
+#
+#   include(esma_sync_data)
+#
+#   esma_sync_data(
+#     TARGET      sync_regression_data
+#     URI         s3://my-bucket/my-data
+#     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/regression_data
+#     ALL
+#   )
+#
+# Optional:
+#
+#   ALL
+#     Add the target to the default build target so that it runs automatically
+#     during a standard build (e.g., `make` or `cmake --build build`). If omitted,
+#     the target is opt-in and must be invoked explicitly (e.g.,
+#     `cmake --build build --target <TARGET>`).
+#
+#     Use ALL when a regression test tree must have the data before tests can run,
+#     and users expect "build everything" to prepare the data.
+#
+#     Omit ALL to avoid unexpected network operations or errors during generic
+#     builds (e.g., on compute nodes without internet access).
+#
+#   REQUIRED
+#     Make sync failures fatal. By default, failures are non-fatal so builds on
+#     compute nodes without internet access can continue.
+#
+#   API_KEY_ENV
+#     Name of the environment variable holding the API key.
+#
+#   CREDENTIALS_URL
+#     URL of the credentials endpoint.
+#
+#   INTERNET_CHECK_URL
+#     Optional URL used as a cheap build-node internet probe before requesting
+#     credentials. If omitted, the credentials request itself is the reachability
+#     test.
+#
+#   AWS_CLI
+#     Path or command name for the AWS CLI. Defaults to "aws", resolved at build
+#     time via PATH.
+
+include_guard(GLOBAL)
+
+function(esma_sync_data)
+  set(options
+    ALL
+    REQUIRED
+  )
+
+  set(oneValueArgs
+    TARGET
+    URI
+    DESTINATION
+    API_KEY_ENV
+    CREDENTIALS_URL
+    INTERNET_CHECK_URL
+    AWS_CLI
+  )
+
+  set(multiValueArgs)
+
+  cmake_parse_arguments(ARG
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
+
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "esma_sync_data: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}"
+    )
+  endif()
+
+  if(NOT ARG_TARGET)
+    message(FATAL_ERROR "esma_sync_data: TARGET is required")
+  endif()
+
+  if(NOT ARG_URI)
+    message(FATAL_ERROR "esma_sync_data: URI is required")
+  endif()
+
+  if(NOT ARG_DESTINATION)
+    message(FATAL_ERROR "esma_sync_data: DESTINATION is required")
+  endif()
+
+  if(NOT ARG_API_KEY_ENV)
+    set(ARG_API_KEY_ENV "AWS_API_KEY_GMAO_SITEAM_S3")
+  endif()
+
+  if(NOT ARG_CREDENTIALS_URL)
+    set(ARG_CREDENTIALS_URL
+      "https://api.example.com/credentials"
+    )
+  endif()
+
+  if(NOT ARG_AWS_CLI)
+    set(ARG_AWS_CLI "aws")
+  endif()
+
+  if(ARG_REQUIRED)
+    set(_required TRUE)
+  else()
+    set(_required FALSE)
+  endif()
+
+  set(_all)
+  if(ARG_ALL)
+    set(_all ALL)
+  endif()
+
+  set(_script "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/esma_sync_data_script.cmake")
+  set(_work_dir "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TARGET}_work")
+
+  add_custom_target(${ARG_TARGET} ${_all}
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${ARG_DESTINATION}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${_work_dir}"
+    COMMAND ${CMAKE_COMMAND}
+      "-DAWS_CLI=${ARG_AWS_CLI}"
+      "-DS3_URI=${ARG_URI}"
+      "-DLOCAL_DIR=${ARG_DESTINATION}"
+      "-DWORK_DIR=${_work_dir}"
+      "-DAPI_KEY_ENV=${ARG_API_KEY_ENV}"
+      "-DCREDENTIALS_URL=${ARG_CREDENTIALS_URL}"
+      "-DINTERNET_CHECK_URL=${ARG_INTERNET_CHECK_URL}"
+      "-DREQUIRED=${_required}"
+      -P "${_script}"
+    COMMENT "Syncing data from ${ARG_URI}"
+    VERBATIM
+  )
+endfunction()

--- a/esma_support/esma_sync_data_script.cmake
+++ b/esma_support/esma_sync_data_script.cmake
@@ -1,0 +1,209 @@
+# esma_sync_data_script.cmake
+#
+# Build-time helper script for esma_sync_data().
+#
+# This file is intentionally run with:
+#
+#   cmake -P esma_sync_data_script.cmake
+#
+# so that all network operations happen at build time, not configure time.
+
+foreach(_var AWS_CLI S3_URI LOCAL_DIR WORK_DIR API_KEY_ENV CREDENTIALS_URL REQUIRED)
+  if(NOT DEFINED ${_var})
+    message(FATAL_ERROR "esma_sync_data_script: ${_var} was not provided")
+  endif()
+endforeach()
+
+file(MAKE_DIRECTORY "${LOCAL_DIR}")
+file(MAKE_DIRECTORY "${WORK_DIR}")
+
+set(_internet_check_file "${WORK_DIR}/internet_check.out")
+
+# Optional generic internet probe.
+#
+# If INTERNET_CHECK_URL is empty, skip this and let the credentials endpoint be
+# the real reachability test. That is usually preferable because it tests the
+# thing we actually need.
+if(DEFINED INTERNET_CHECK_URL AND NOT INTERNET_CHECK_URL STREQUAL "")
+  message(STATUS "Checking build-node internet access using ${INTERNET_CHECK_URL}")
+
+  file(DOWNLOAD
+    "${INTERNET_CHECK_URL}"
+    "${_internet_check_file}"
+    STATUS _internet_status
+    TIMEOUT 10
+    INACTIVITY_TIMEOUT 10
+    TLS_VERIFY ON
+  )
+
+  list(GET _internet_status 0 _internet_code)
+  list(GET _internet_status 1 _internet_message)
+
+  file(REMOVE "${_internet_check_file}")
+
+  if(NOT _internet_code EQUAL 0)
+    if(REQUIRED)
+      message(FATAL_ERROR
+        "No internet access from this build node; cannot sync ${S3_URI}: "
+        "${_internet_message}"
+      )
+    else()
+      message(STATUS
+        "Skipping data sync from ${S3_URI}: no internet access from this "
+        "build node: ${_internet_message}"
+      )
+      return()
+    endif()
+  endif()
+endif()
+
+# API key must be available in the build environment.
+if(NOT DEFINED ENV{${API_KEY_ENV}} OR "$ENV{${API_KEY_ENV}}" STREQUAL "")
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Required environment variable ${API_KEY_ENV} is not set; "
+      "cannot sync ${S3_URI}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: environment variable "
+      "${API_KEY_ENV} is not set"
+    )
+    return()
+  endif()
+endif()
+
+find_program(CURL_PROGRAM curl)
+
+if(NOT CURL_PROGRAM)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "curl command-line tool not found; cannot securely retrieve AWS credentials. "
+      "curl is required to prevent credentials from being written to disk."
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: curl command-line tool not found."
+    )
+    return()
+  endif()
+endif()
+
+message(STATUS "Requesting temporary AWS credentials securely via curl (in-memory)")
+
+# Relay the API key through a temporary child-only environment variable so it
+# never appears in any process command-line list (ps/top) and is never written
+# to disk.  sh reads it from its own environment and pipes it to curl's stdin;
+# it is only visible in /proc/<pid>/environ, readable solely by the owner and
+# root.
+set(ENV{_ESMA_CURL_HDR} "header = \"x-api-key: $ENV{${API_KEY_ENV}}\"")
+
+execute_process(
+  COMMAND sh -c
+    "printf '%s\n' \"$_ESMA_CURL_HDR\" | \"${CURL_PROGRAM}\" -s -S -f -K - --connect-timeout 20 --max-time 30 \"${CREDENTIALS_URL}\""
+  OUTPUT_VARIABLE _creds_json
+  ERROR_VARIABLE _curl_err
+  RESULT_VARIABLE _curl_code
+)
+
+unset(ENV{_ESMA_CURL_HDR})
+
+if(NOT _curl_code EQUAL 0)
+  string(STRIP "${_curl_err}" _curl_err_clean)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Could not securely retrieve AWS credentials for ${S3_URI} via curl (exit code ${_curl_code}): ${_curl_err_clean}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: could not securely retrieve AWS credentials: "
+      "${_curl_err_clean}"
+    )
+    return()
+  endif()
+endif()
+
+string(JSON AWS_ACCESS_KEY_ID
+  ERROR_VARIABLE _json_error
+  GET "${_creds_json}" AccessKeyId
+)
+
+if(_json_error)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Could not parse AccessKeyId from credentials response: ${_json_error}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: could not parse AccessKeyId from "
+      "credentials response: ${_json_error}"
+    )
+    return()
+  endif()
+endif()
+
+string(JSON AWS_SECRET_ACCESS_KEY
+  ERROR_VARIABLE _json_error
+  GET "${_creds_json}" SecretAccessKey
+)
+
+if(_json_error)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Could not parse SecretAccessKey from credentials response: ${_json_error}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: could not parse SecretAccessKey from "
+      "credentials response: ${_json_error}"
+    )
+    return()
+  endif()
+endif()
+
+string(JSON AWS_SESSION_TOKEN
+  ERROR_VARIABLE _json_error
+  GET "${_creds_json}" SessionToken
+)
+
+if(_json_error)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Could not parse SessionToken from credentials response: ${_json_error}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: could not parse SessionToken from "
+      "credentials response: ${_json_error}"
+    )
+    return()
+  endif()
+endif()
+
+message(STATUS "Syncing ${S3_URI} to ${LOCAL_DIR}")
+
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E env
+    AWS_EC2_METADATA_DISABLED=true
+    AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+    AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+    ${AWS_CLI} s3 sync --only-show-errors "${S3_URI}" "${LOCAL_DIR}"
+  RESULT_VARIABLE _aws_result
+)
+
+if(NOT _aws_result EQUAL 0)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "aws s3 sync failed for ${S3_URI}; exit code: ${_aws_result}"
+    )
+  else()
+    message(STATUS
+      "Data sync from ${S3_URI} failed non-fatally; aws exit code: "
+      "${_aws_result}"
+    )
+    return()
+  endif()
+endif()
+
+message(STATUS "Finished syncing ${S3_URI}")


### PR DESCRIPTION
Adds support for build-time data synchronization from S3 via the new `esma_sync_data()` macro, which requests temporary AWS credentials and executes `aws s3 sync`.

### Optional `ALL` Argument

By default, omitting `ALL` means the custom target is created but not added to the default build. This is highly recommended for developers or typical compilation builds to prevent unexpected/unwanted network operations and dependency on S3.
Specifying `ALL` adds the target to the default build, causing the synchronization to run automatically when the project is built. This is suitable for automated regression/CI pipelines or container environments.

### Usage Examples

```cmake
# Recommended for standard setups (target created but not automatically run)
esma_sync_data(
  TARGET      sync_regression_data
  URI         s3://my-bucket/my-data
  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/regression_data
)
```

If you wish to wire the target into the default build automatically:

```cmake
esma_sync_data(
  TARGET      sync_regression_data
  URI         s3://my-bucket/my-data
  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/regression_data
  ALL
)
```

Or, if the data is absolutely required for a particular build/test workflow (failure to download will halt the build):

```cmake
esma_sync_data(
  TARGET      sync_regression_data
  URI         s3://my-bucket/my-data
  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/regression_data
  ALL
  REQUIRED
)
```