### PR TITLE
v5: Port color_message, esma_sync_data, and FMS YAML autodetection from v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [5.12.0] - 2026-06-17
+
+### Added
+
+- Added new `esma_color_message.cmake` which adds a `color_message` function
+- Added `check_fms_yaml_support` macro (`external_libraries/check_fms_yaml_support.cmake` + `external_libraries/test_fms_yaml.f90`) to autodetect whether FMS was built with YAML support via a `try_compile` probe, replacing the manual `FMS_BUILT_WITH_YAML` option. Note: once we move to FMS 2026.01 ([NOAA-GFDL/FMS#1822](https://github.com/NOAA-GFDL/FMS/pull/1822)), FMS will export libyaml as a proper `find_dependency` and this probe (along with `Findlibyaml.cmake`) can be removed.
+- Added `esma_sync_data()` CMake macro and build-time helper script to support build-time synchronization of data from AWS S3 buckets using temporary AWS credentials.
+
+### Changed
+
+- Update `FindF2PY.cmake` and `FindF2PY3.cmake` to use `color_message` instead of a `message(WARNING)` (as with Spack we would always trigger the warning)
+- Suppress duplicate f2py/Python executable mismatch warnings when `find_package` is called multiple times in the same configure run, using a global-property once-only guard.
+
 ## [5.11.0] - 2026-06-04
 
 ### Changed

--- a/esma_support/esma_color_message.cmake
+++ b/esma_support/esma_color_message.cmake
@@ -1,0 +1,64 @@
+function(color_message COLOR MSG_TYPE MSG_STRING)
+  # 1. Respect the standard NO_COLOR environment variable
+  if(DEFINED ENV{NO_COLOR})
+    message(${MSG_TYPE} "${MSG_STRING}")
+    return()
+  endif()
+
+  # 2. Pass-through for non-STATUS messages
+  if(NOT MSG_TYPE STREQUAL "STATUS")
+    message(${MSG_TYPE} "${MSG_STRING}")
+    return()
+  endif()
+
+  # 3. Define the full palette locally
+  string(ASCII 27 ESC)
+  set(RESET "${ESC}[0m")
+
+  # Standard Colors
+  set(RED     "${ESC}[31m")
+  set(GREEN   "${ESC}[32m")
+  set(YELLOW  "${ESC}[33m")
+  set(BLUE    "${ESC}[34m")
+  set(MAGENTA "${ESC}[35m")
+  set(CYAN    "${ESC}[36m")
+  set(WHITE   "${ESC}[37m")
+
+  # Bold Standard Colors
+  set(BOLD_RED     "${ESC}[1;31m")
+  set(BOLD_GREEN   "${ESC}[1;32m")
+  set(BOLD_YELLOW  "${ESC}[1;33m")
+  set(BOLD_BLUE    "${ESC}[1;34m")
+  set(BOLD_MAGENTA "${ESC}[1;35m")
+  set(BOLD_CYAN    "${ESC}[1;36m")
+  set(BOLD_WHITE   "${ESC}[1;37m")
+
+  # Extended 256-Color Palette
+  set(ORANGE       "${ESC}[1;38;5;214m")
+  set(HOT_PINK     "${ESC}[1;38;5;198m")
+  set(LIME         "${ESC}[1;38;5;154m")
+  set(ELECTRIC_BLU "${ESC}[1;38;5;45m")
+  set(LAVENDER     "${ESC}[1;38;5;147m")
+
+  # 4. Define the list of explicitly supported colors
+  set(SUPPORTED_COLORS
+    RED GREEN YELLOW BLUE MAGENTA CYAN WHITE
+    BOLD_RED BOLD_GREEN BOLD_YELLOW BOLD_BLUE BOLD_MAGENTA BOLD_CYAN BOLD_WHITE
+    ORANGE HOT_PINK LIME ELECTRIC_BLU LAVENDER
+  )
+
+  # 5. Validate the requested color
+  list(FIND SUPPORTED_COLORS "${COLOR}" COLOR_INDEX)
+
+  if(COLOR_INDEX EQUAL -1)
+    # The color is not in our list. Warn the developer and fallback to no color.
+    message(AUTHOR_WARNING "color_message: Invalid color requested ('${COLOR}'). Supported colors are: ${SUPPORTED_COLORS}")
+    set(ACTIVE_COLOR "")
+  else()
+    # The color is valid. Dynamically resolve its escape code.
+    set(ACTIVE_COLOR "${${COLOR}}")
+  endif()
+
+  # 6. Print the formatted message
+  message(STATUS "${ACTIVE_COLOR}${MSG_STRING}${RESET}")
+endfunction()

--- a/esma_support/esma_support.cmake
+++ b/esma_support/esma_support.cmake
@@ -1,15 +1,17 @@
 # CMake code that supports ESMA
 
-include (esma_check_if_debug)
-include (esma_set_this)
-include (esma_add_subdirectories)
-include (esma_mepo_style)
-include (esma_add_library)
-include (esma_generate_automatic_code)
-include (esma_create_stub_component)
-include (esma_fortran_generator_list)
-include (esma_add_fortran_submodules)
-include (esma_mepo_status)
+include(esma_check_if_debug)
+include(esma_set_this)
+include(esma_add_subdirectories)
+include(esma_mepo_style)
+include(esma_add_library)
+include(esma_generate_automatic_code)
+include(esma_create_stub_component)
+include(esma_fortran_generator_list)
+include(esma_add_fortran_submodules)
+include(esma_mepo_status)
+include(esma_color_message)
+include(esma_sync_data)
 
 # Testing
-include (esma_enable_tests)
+include(esma_enable_tests)

--- a/esma_support/esma_sync_data.cmake
+++ b/esma_support/esma_sync_data.cmake
@@ -1,0 +1,138 @@
+# esma_sync_data.cmake
+#
+# Define build-time data sync targets.
+#
+# Example:
+#
+#   include(esma_sync_data)
+#
+#   esma_sync_data(
+#     TARGET      sync_regression_data
+#     URI         s3://my-bucket/my-data
+#     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/regression_data
+#     ALL
+#   )
+#
+# Optional:
+#
+#   ALL
+#     Add the target to the default build target so that it runs automatically
+#     during a standard build (e.g., `make` or `cmake --build build`). If omitted,
+#     the target is opt-in and must be invoked explicitly (e.g.,
+#     `cmake --build build --target <TARGET>`).
+#
+#     Use ALL when a regression test tree must have the data before tests can run,
+#     and users expect "build everything" to prepare the data.
+#
+#     Omit ALL to avoid unexpected network operations or errors during generic
+#     builds (e.g., on compute nodes without internet access).
+#
+#   REQUIRED
+#     Make sync failures fatal. By default, failures are non-fatal so builds on
+#     compute nodes without internet access can continue.
+#
+#   API_KEY_ENV
+#     Name of the environment variable holding the API key.
+#
+#   CREDENTIALS_URL
+#     URL of the credentials endpoint.
+#
+#   INTERNET_CHECK_URL
+#     Optional URL used as a cheap build-node internet probe before requesting
+#     credentials. If omitted, the credentials request itself is the reachability
+#     test.
+#
+#   AWS_CLI
+#     Path or command name for the AWS CLI. Defaults to "aws", resolved at build
+#     time via PATH.
+
+include_guard(GLOBAL)
+
+function(esma_sync_data)
+  set(options
+    ALL
+    REQUIRED
+  )
+
+  set(oneValueArgs
+    TARGET
+    URI
+    DESTINATION
+    API_KEY_ENV
+    CREDENTIALS_URL
+    INTERNET_CHECK_URL
+    AWS_CLI
+  )
+
+  set(multiValueArgs)
+
+  cmake_parse_arguments(ARG
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
+
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "esma_sync_data: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}"
+    )
+  endif()
+
+  if(NOT ARG_TARGET)
+    message(FATAL_ERROR "esma_sync_data: TARGET is required")
+  endif()
+
+  if(NOT ARG_URI)
+    message(FATAL_ERROR "esma_sync_data: URI is required")
+  endif()
+
+  if(NOT ARG_DESTINATION)
+    message(FATAL_ERROR "esma_sync_data: DESTINATION is required")
+  endif()
+
+  if(NOT ARG_API_KEY_ENV)
+    set(ARG_API_KEY_ENV "AWS_API_KEY_GMAO_SITEAM_S3")
+  endif()
+
+  if(NOT ARG_CREDENTIALS_URL)
+    set(ARG_CREDENTIALS_URL
+      "https://api.example.com/credentials"
+    )
+  endif()
+
+  if(NOT ARG_AWS_CLI)
+    set(ARG_AWS_CLI "aws")
+  endif()
+
+  if(ARG_REQUIRED)
+    set(_required TRUE)
+  else()
+    set(_required FALSE)
+  endif()
+
+  set(_all)
+  if(ARG_ALL)
+    set(_all ALL)
+  endif()
+
+  set(_script "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/esma_sync_data_script.cmake")
+  set(_work_dir "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TARGET}_work")
+
+  add_custom_target(${ARG_TARGET} ${_all}
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${ARG_DESTINATION}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${_work_dir}"
+    COMMAND ${CMAKE_COMMAND}
+      "-DAWS_CLI=${ARG_AWS_CLI}"
+      "-DS3_URI=${ARG_URI}"
+      "-DLOCAL_DIR=${ARG_DESTINATION}"
+      "-DWORK_DIR=${_work_dir}"
+      "-DAPI_KEY_ENV=${ARG_API_KEY_ENV}"
+      "-DCREDENTIALS_URL=${ARG_CREDENTIALS_URL}"
+      "-DINTERNET_CHECK_URL=${ARG_INTERNET_CHECK_URL}"
+      "-DREQUIRED=${_required}"
+      -P "${_script}"
+    COMMENT "Syncing data from ${ARG_URI}"
+    VERBATIM
+  )
+endfunction()

--- a/esma_support/esma_sync_data_script.cmake
+++ b/esma_support/esma_sync_data_script.cmake
@@ -1,0 +1,209 @@
+# esma_sync_data_script.cmake
+#
+# Build-time helper script for esma_sync_data().
+#
+# This file is intentionally run with:
+#
+#   cmake -P esma_sync_data_script.cmake
+#
+# so that all network operations happen at build time, not configure time.
+
+foreach(_var AWS_CLI S3_URI LOCAL_DIR WORK_DIR API_KEY_ENV CREDENTIALS_URL REQUIRED)
+  if(NOT DEFINED ${_var})
+    message(FATAL_ERROR "esma_sync_data_script: ${_var} was not provided")
+  endif()
+endforeach()
+
+file(MAKE_DIRECTORY "${LOCAL_DIR}")
+file(MAKE_DIRECTORY "${WORK_DIR}")
+
+set(_internet_check_file "${WORK_DIR}/internet_check.out")
+
+# Optional generic internet probe.
+#
+# If INTERNET_CHECK_URL is empty, skip this and let the credentials endpoint be
+# the real reachability test. That is usually preferable because it tests the
+# thing we actually need.
+if(DEFINED INTERNET_CHECK_URL AND NOT INTERNET_CHECK_URL STREQUAL "")
+  message(STATUS "Checking build-node internet access using ${INTERNET_CHECK_URL}")
+
+  file(DOWNLOAD
+    "${INTERNET_CHECK_URL}"
+    "${_internet_check_file}"
+    STATUS _internet_status
+    TIMEOUT 10
+    INACTIVITY_TIMEOUT 10
+    TLS_VERIFY ON
+  )
+
+  list(GET _internet_status 0 _internet_code)
+  list(GET _internet_status 1 _internet_message)
+
+  file(REMOVE "${_internet_check_file}")
+
+  if(NOT _internet_code EQUAL 0)
+    if(REQUIRED)
+      message(FATAL_ERROR
+        "No internet access from this build node; cannot sync ${S3_URI}: "
+        "${_internet_message}"
+      )
+    else()
+      message(STATUS
+        "Skipping data sync from ${S3_URI}: no internet access from this "
+        "build node: ${_internet_message}"
+      )
+      return()
+    endif()
+  endif()
+endif()
+
+# API key must be available in the build environment.
+if(NOT DEFINED ENV{${API_KEY_ENV}} OR "$ENV{${API_KEY_ENV}}" STREQUAL "")
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Required environment variable ${API_KEY_ENV} is not set; "
+      "cannot sync ${S3_URI}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: environment variable "
+      "${API_KEY_ENV} is not set"
+    )
+    return()
+  endif()
+endif()
+
+find_program(CURL_PROGRAM curl)
+
+if(NOT CURL_PROGRAM)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "curl command-line tool not found; cannot securely retrieve AWS credentials. "
+      "curl is required to prevent credentials from being written to disk."
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: curl command-line tool not found."
+    )
+    return()
+  endif()
+endif()
+
+message(STATUS "Requesting temporary AWS credentials securely via curl (in-memory)")
+
+# Relay the API key through a temporary child-only environment variable so it
+# never appears in any process command-line list (ps/top) and is never written
+# to disk.  sh reads it from its own environment and pipes it to curl's stdin;
+# it is only visible in /proc/<pid>/environ, readable solely by the owner and
+# root.
+set(ENV{_ESMA_CURL_HDR} "header = \"x-api-key: $ENV{${API_KEY_ENV}}\"")
+
+execute_process(
+  COMMAND sh -c
+    "printf '%s\n' \"$_ESMA_CURL_HDR\" | \"${CURL_PROGRAM}\" -s -S -f -K - --connect-timeout 20 --max-time 30 \"${CREDENTIALS_URL}\""
+  OUTPUT_VARIABLE _creds_json
+  ERROR_VARIABLE _curl_err
+  RESULT_VARIABLE _curl_code
+)
+
+unset(ENV{_ESMA_CURL_HDR})
+
+if(NOT _curl_code EQUAL 0)
+  string(STRIP "${_curl_err}" _curl_err_clean)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Could not securely retrieve AWS credentials for ${S3_URI} via curl (exit code ${_curl_code}): ${_curl_err_clean}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: could not securely retrieve AWS credentials: "
+      "${_curl_err_clean}"
+    )
+    return()
+  endif()
+endif()
+
+string(JSON AWS_ACCESS_KEY_ID
+  ERROR_VARIABLE _json_error
+  GET "${_creds_json}" AccessKeyId
+)
+
+if(_json_error)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Could not parse AccessKeyId from credentials response: ${_json_error}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: could not parse AccessKeyId from "
+      "credentials response: ${_json_error}"
+    )
+    return()
+  endif()
+endif()
+
+string(JSON AWS_SECRET_ACCESS_KEY
+  ERROR_VARIABLE _json_error
+  GET "${_creds_json}" SecretAccessKey
+)
+
+if(_json_error)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Could not parse SecretAccessKey from credentials response: ${_json_error}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: could not parse SecretAccessKey from "
+      "credentials response: ${_json_error}"
+    )
+    return()
+  endif()
+endif()
+
+string(JSON AWS_SESSION_TOKEN
+  ERROR_VARIABLE _json_error
+  GET "${_creds_json}" SessionToken
+)
+
+if(_json_error)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "Could not parse SessionToken from credentials response: ${_json_error}"
+    )
+  else()
+    message(STATUS
+      "Skipping data sync from ${S3_URI}: could not parse SessionToken from "
+      "credentials response: ${_json_error}"
+    )
+    return()
+  endif()
+endif()
+
+message(STATUS "Syncing ${S3_URI} to ${LOCAL_DIR}")
+
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E env
+    AWS_EC2_METADATA_DISABLED=true
+    AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+    AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+    ${AWS_CLI} s3 sync --only-show-errors "${S3_URI}" "${LOCAL_DIR}"
+  RESULT_VARIABLE _aws_result
+)
+
+if(NOT _aws_result EQUAL 0)
+  if(REQUIRED)
+    message(FATAL_ERROR
+      "aws s3 sync failed for ${S3_URI}; exit code: ${_aws_result}"
+    )
+  else()
+    message(STATUS
+      "Data sync from ${S3_URI} failed non-fatally; aws exit code: "
+      "${_aws_result}"
+    )
+    return()
+  endif()
+endif()
+
+message(STATUS "Finished syncing ${S3_URI}")

--- a/external_libraries/FindBaselibs.cmake
+++ b/external_libraries/FindBaselibs.cmake
@@ -335,14 +335,6 @@ if (Baselibs_FOUND)
 
   if (DEFINED FV_PRECISION)
     message(STATUS "Looking for FMS")
-    # libyaml
-    option(FMS_BUILT_WITH_YAML "FMS was built with YAML" OFF)
-    if (FMS_BUILT_WITH_YAML)
-      # We use the same Findlibyaml.cmake that FMS uses
-      find_package(libyaml REQUIRED)
-      message(STATUS "LIBYAML_INCLUDE_DIR: ${LIBYAML_INCLUDE_DIR}")
-      message(STATUS "LIBYAML_LIBRARIES: ${LIBYAML_LIBRARIES}")
-    endif ()
 
     # - fms
     # Use find_path and find_library to find the include and library
@@ -358,7 +350,19 @@ if (Baselibs_FOUND)
       INTERFACE_LINK_LIBRARIES  "NetCDF::NetCDF_Fortran;MPI::MPI_Fortran"
       INTERFACE_LINK_DIRECTORIES "${FMS_LIBRARIES_DIR}"
     )
+
+    # Probe whether FMS was built with YAML support by attempting to compile
+    # a small Fortran file that uses yaml_parser_mod from FMS.
+    # NOTE: As of FMS 2026.01 (NOAA-GFDL/FMS#1822), FMS exports libyaml as a
+    # proper dependency in fms-config.cmake via find_dependency, so the probe,
+    # find_package(libyaml), and target_link_libraries calls below can all be
+    # removed once we move to FMS 2026.01 or later.
+    include(check_fms_yaml_support)
+    check_fms_yaml_support(FMS_BUILT_WITH_YAML)
     if (FMS_BUILT_WITH_YAML)
+      find_package(libyaml REQUIRED)
+      message(STATUS "LIBYAML_INCLUDE_DIR: ${LIBYAML_INCLUDE_DIR}")
+      message(STATUS "LIBYAML_LIBRARIES: ${LIBYAML_LIBRARIES}")
       target_link_libraries(FMS::fms INTERFACE ${LIBYAML_LIBRARIES})
     endif ()
     # We will set FMS_FOUND if both FMS_LIBRARIES and FMS_INCLUDE_DIR are found

--- a/external_libraries/Findlibyaml.cmake
+++ b/external_libraries/Findlibyaml.cmake
@@ -2,6 +2,10 @@
 # The following variables are set:
 #    LIBYAML_INCLUDE_DIR
 #    LIBYAML_LIBRARIES
+#
+# NOTE: As of FMS 2026.01 (NOAA-GFDL/FMS#1822), FMS uses pkg-config to find
+# libyaml and exports it as a dependency in fms-config.cmake. This file will
+# no longer be needed once we move to FMS 2026.01 or later and can be removed.
 
 FIND_PATH(LIBYAML_INCLUDE_DIR  NAMES yaml.h  PATHS ${LIBYAML_ROOT}/include $ENV{LIBYAML_ROOT}/include )
 FIND_LIBRARY(LIBYAML_LIBRARIES NAMES yaml    PATHS ${LIBYAML_ROOT}/lib     $ENV{LIBYAML_ROOT}/lib )

--- a/external_libraries/check_fms_yaml_support.cmake
+++ b/external_libraries/check_fms_yaml_support.cmake
@@ -1,0 +1,41 @@
+# Capture the directory of this file at include time, before the macro is invoked
+# (CMAKE_CURRENT_LIST_DIR changes when the macro body runs)
+set(_CHECK_FMS_YAML_SUPPORT_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+macro(check_fms_yaml_support result_var)
+  # Select the FMS target to probe against.
+  set(_FMS_YAML_TARGET FMS::fms)
+
+  get_target_property(_FMS_YAML_INCLUDE_DIRS ${_FMS_YAML_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
+  if(NOT _FMS_YAML_INCLUDE_DIRS)
+    set(_FMS_YAML_INCLUDE_DIRS "")
+  endif()
+
+  set(_TEST_FILE_PATH "${_CHECK_FMS_YAML_SUPPORT_DIR}/test_fms_yaml.f90")
+  if(NOT EXISTS "${_TEST_FILE_PATH}")
+    message(FATAL_ERROR "FMS YAML test file not found: ${_TEST_FILE_PATH}")
+  endif()
+
+  # Compile-only probe (STATIC_LIBRARY avoids needing libyaml at this stage)
+  set(_SAVED_CMAKE_TRY_COMPILE_TARGET_TYPE ${CMAKE_TRY_COMPILE_TARGET_TYPE})
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+  set(_CMAKE_FLAGS_LIST "")
+  if(_FMS_YAML_INCLUDE_DIRS)
+    list(APPEND _CMAKE_FLAGS_LIST "-DINCLUDE_DIRECTORIES=${_FMS_YAML_INCLUDE_DIRS}")
+  endif()
+
+  try_compile(${result_var}
+    ${CMAKE_BINARY_DIR}/test_fms_yaml_compile
+    SOURCES ${_TEST_FILE_PATH}
+    CMAKE_FLAGS ${_CMAKE_FLAGS_LIST}
+  )
+
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE ${_SAVED_CMAKE_TRY_COMPILE_TARGET_TYPE})
+
+  if(${result_var})
+    message(STATUS "FMS YAML support detected.")
+  else()
+    message(STATUS "FMS YAML support NOT detected.")
+  endif()
+endmacro()

--- a/external_libraries/test_fms_yaml.f90
+++ b/external_libraries/test_fms_yaml.f90
@@ -1,0 +1,4 @@
+subroutine test_fms_yaml
+  use yaml_parser_mod, only: open_and_parse_file
+  implicit none
+end subroutine test_fms_yaml

--- a/python/f2py/FindF2PY.cmake
+++ b/python/f2py/FindF2PY.cmake
@@ -94,9 +94,15 @@ message(DEBUG "[F2PY]: f2py executable directory: ${F2PY_EXECUTABLE_DIR}")
 # Now we issue a WARNING. We can't do more than that because of things like Spack
 # where f2py will be in a different location than python.
 if (NOT "${F2PY_EXECUTABLE_DIR}" STREQUAL "${Python_EXECUTABLE_DIR}")
-  message(WARNING
-    "[F2PY]: The f2py executable [${F2PY_EXECUTABLE}] found is not the one associated with the Python_EXECUTABLE [${Python_EXECUTABLE}].\n"
-    "Please check your Python environment if this is not expected (for example, not a Spack install) or build with -DUSE_F2PY=OFF.")
+  # Use a global property as a once-only guard so this message is emitted at
+  # most once per configure run, even if find_package(F2PY) is called multiple
+  # times (e.g. from different subdirectories).
+  get_property(_f2py_mismatch_warned GLOBAL PROPERTY _F2PY_MISMATCH_WARNED)
+  if (NOT _f2py_mismatch_warned)
+    color_message(ORANGE STATUS
+      "[F2PY]: The f2py executable [${F2PY_EXECUTABLE}] found is not the one associated with the Python_EXECUTABLE [${Python_EXECUTABLE}].\nPlease check your Python environment if this is not expected (for example, not a Spack install) or build with -DUSE_F2PY=OFF.")
+    set_property(GLOBAL PROPERTY _F2PY_MISMATCH_WARNED TRUE)
+  endif ()
 endif ()
 
 if(F2PY_EXECUTABLE)

--- a/python/f2py3/FindF2PY3.cmake
+++ b/python/f2py3/FindF2PY3.cmake
@@ -94,9 +94,15 @@ message(DEBUG "[F2PY3]: f2py3 executable directory: ${F2PY3_EXECUTABLE_DIR}")
 # Now we issue a WARNING. We can't do more than that because of things like Spack
 # where f2py will be in a different location than python.
 if (NOT "${F2PY3_EXECUTABLE_DIR}" STREQUAL "${Python3_EXECUTABLE_DIR}")
-  message(WARNING
-    "[F2PY3]: The f2py3 executable [${F2PY3_EXECUTABLE}] found is not the one associated with the Python3_EXECUTABLE [${Python3_EXECUTABLE}].\n"
-    "Please check your Python3 environment if this is not expected (for example, not a Spack install) or build with -DUSE_F2PY=OFF.")
+  # Use a global property as a once-only guard so this message is emitted at
+  # most once per configure run, even if find_package(F2PY3) is called multiple
+  # times (e.g. from different subdirectories).
+  get_property(_f2py3_mismatch_warned GLOBAL PROPERTY _F2PY3_MISMATCH_WARNED)
+  if (NOT _f2py3_mismatch_warned)
+    color_message(ORANGE STATUS
+      "[F2PY3]: The f2py3 executable [${F2PY3_EXECUTABLE}] found is not the one associated with the Python3_EXECUTABLE [${Python3_EXECUTABLE}].\nPlease check your Python3 environment if this is not expected (for example, not a Spack install) or build with -DUSE_F2PY=OFF.")
+    set_property(GLOBAL PROPERTY _F2PY3_MISMATCH_WARNED TRUE)
+  endif ()
 endif ()
 
 if(F2PY3_EXECUTABLE)


### PR DESCRIPTION
This PR ports the newly added functionalities from release/v4 to the v5 develop branch, adapting them to the unified `FMS::fms` target structure of v5:

1. **`color_message` Functionality:** Adds `esma_support/esma_color_message.cmake` and replaces Python/f2py executable mismatch warnings with colored status messages using a global property once-only guard.
2. **`esma_sync_data` Macro & Script:** Adds support for build-time S3 data synchronization using temporary AWS credentials, featuring the piped `curl` stdin API key fix and automatic credential/probe file disk cleanup.
3. **Autodetect FMS YAML Support:** Adds the `check_fms_yaml_support` compile-only probe, adapted to the unified `FMS::fms` target of v5.