### PR TITLE
v4: Create manifest and fix macOS RPATH for relocatable installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add new `esma_install_manifest.cmake` to create a manifest of installed files
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Switch macOS RPATH in `osx_extras.cmake` from absolute `${CMAKE_INSTALL_PREFIX}/lib` to relative `@loader_path/../lib` and set `ENABLE_RELATIVE_RPATHS TRUE` so that experiment-local install trees (`EXPDIR/install/bin/GEOSgcm.x`) resolve GEOS/MAPL shared libraries from their own `EXPDIR/install/lib` without referencing the original build prefix
+
 ### Deprecated
 
 ## [4.40.0] - 2026-06-17

--- a/esma_install_manifest.cmake
+++ b/esma_install_manifest.cmake
@@ -1,0 +1,34 @@
+# esma_install_manifest.cmake
+
+set(_prefix "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}")
+set(_manifest "${_prefix}/etc/GEOS_RUNTIME_MANIFEST.sha256")
+
+file(MAKE_DIRECTORY "${_prefix}/etc")
+
+file(GLOB_RECURSE _files
+  LIST_DIRECTORIES false
+  "${_prefix}/bin/*.x"
+  "${_prefix}/lib/*.so"
+  "${_prefix}/lib/*.so.*"
+)
+
+list(SORT _files)
+
+file(WRITE "${_manifest}" "# GEOS runtime manifest\n")
+file(APPEND "${_manifest}" "# prefix: ${CMAKE_INSTALL_PREFIX}\n")
+file(APPEND "${_manifest}" "# format: sha256 size relative_path\n")
+
+foreach(_file IN LISTS _files)
+  if("${_file}" STREQUAL "${_manifest}")
+    continue()
+  endif()
+
+  if(EXISTS "${_file}" AND NOT IS_DIRECTORY "${_file}")
+    file(SHA256 "${_file}" _sha)
+    file(SIZE "${_file}" _size)
+    file(RELATIVE_PATH _rel "${_prefix}" "${_file}")
+    file(APPEND "${_manifest}" "${_sha}  ${_size}  ${_rel}\n")
+  endif()
+endforeach()
+
+message(STATUS "Wrote GEOS runtime manifest: ${_manifest}")

--- a/operating_system/osx_extras.cmake
+++ b/operating_system/osx_extras.cmake
@@ -19,9 +19,23 @@ foreach(lang Fortran C CXX)
 #  set (CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS}  -Wl,-no_compact_unwind")
 endforeach()
 
-
-
-# 3) Rpath handling per https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling#always-full-rpath
+# 3) Rpath handling
+#
+# GEOS uses an install-tree layout like:
+#
+#   install/bin/GEOSgcm.x
+#   install/lib/*.dylib
+#
+# On Linux this is handled with:
+#
+#   $ORIGIN/../lib
+#
+# On macOS/Darwin the equivalent is:
+#
+#   @loader_path/../lib
+#
+# This allows an experiment-local copy of install/bin and install/lib
+# to be self-contained.
 
 ## use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
@@ -30,32 +44,31 @@ set(CMAKE_SKIP_BUILD_RPATH FALSE)
 ## (but later on when installing)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+## Historically we used ${CMAKE_INSTALL_PREFIX}/lib here following the
+## "always full RPATH" CMake guidance. That worked for running directly
+## from the build install prefix, but it prevents experiment-local install
+## trees from being self-contained: a copied EXPDIR/install/bin/GEOSgcm.x
+## keeps loading GEOS dylibs from the original install prefix.
+##
+## Use the Darwin equivalent of Linux $ORIGIN/../lib instead.
+set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
 
-## add the automatically determined parts of the RPATH
-## which point to directories outside the build tree to the install RPATH
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+## Do not automatically append link directories to the install RPATH.
+## In particular, avoid hard-wiring ${CMAKE_INSTALL_PREFIX}/lib into
+## installed executables, since that defeats experiment-local install trees.
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 
-## the RPATH to be used when installing, but only if it's not a system directory
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-if("${isSystemDir}" STREQUAL "-1")
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-endif("${isSystemDir}" STREQUAL "-1")
-
-
-# 4) With the advent of shared libraries in GEOS, one needs to symlink install/lib in an experiment
-#    or use this command
-ecbuild_info(
-   "Setting ENABLE_RELATIVE_RPATHS to FALSE.\n"
-   "This changes LC_RPATH in the executable from:\n"
-   " path @loader_path/../lib\n"
-   "to:\n"
-   " path ${CMAKE_INSTALL_PREFIX}/lib"
-   )
-set (ENABLE_RELATIVE_RPATHS FALSE)
-
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-headerpad_max_install_names")
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-headerpad_max_install_names")
+# 4) With the advent of shared libraries in GEOS, installed executables
+# should use relative RPATHs so that:
+#
+#   EXPDIR/install/bin/GEOSgcm.x
+#
+# resolves GEOS/MAPL shared libraries from:
+#
+#   EXPDIR/install/lib
+#
+message(STATUS "Setting ENABLE_RELATIVE_RPATHS to TRUE. This keeps LC_RPATH in installed executables relocatable: path @loader_path/../lib")
+set(ENABLE_RELATIVE_RPATHS TRUE)
 
 # 5) Flang compiler workarounds for macOS shared libraries
 # CMake natively uses Apple's '-dynamiclib' and '-install_name' for shared libraries,


### PR DESCRIPTION
This is part of a suite of PRs to try and change how we handle `GEOSgcm.x` in GEOS. The issue is that more and more of GEOS subcomponents are becoming shared object libraries instead of static. 

## Overall Problem

That means the old trick of "copy someone else's `GEOSgcm.x` to my experiment" might not work. Why? Well, in GEOSgcm v11.10+, the Moist GridComp (for example) is now a shared object library and so just copying `GEOSgcm.x` isn't enough to actually use that other person's Moist GC code.

## What we change here 

### 1. Runtime manifest (`esma_install_manifest.cmake`)

We add a new cmake script that runs after `install`. It creates a "manifest" as it were. So, if a user has two experiments, you can compare the manifests that will be in the install to see what might have changed (not perfect, but better than nothing). For example, if you diff two manifests:

```
> diff installdir-v12-2026Jun23-1day-c48/install/GEOS_RUNTIME_MANIFEST.sha256 installdir-v12-2026Jun23-1day-c48-ChangeMoist-Try3/install/GEOS_RUNTIME_MANIFEST.sha256
190c190
< 01082779e76498ec996b15f7b06acd300384d7bb62b58091977c5204d1c14de1  9482728  lib/libGEOSmoist_GridComp.so
---
> b5f1b1ee19c614bf071f1d9004eec62dfcb1e021dc2a47ae2f0f1509d1bbf713  9482728  lib/libGEOSmoist_GridComp.so
```

### 2. macOS relocatable RPATH (`osx_extras.cmake`)

Switch from the old absolute `${CMAKE_INSTALL_PREFIX}/lib` RPATH to a relative `@loader_path/../lib` RPATH (the macOS equivalent of Linux `$ORIGIN/../lib`), and set `ENABLE_RELATIVE_RPATHS TRUE`. This makes experiment-local install trees self-contained:

```
EXPDIR/install/bin/GEOSgcm.x  →  resolves dylibs from  EXPDIR/install/lib
```

Previously, a copied `GEOSgcm.x` would still load GEOS/MAPL shared libraries from the **original** build prefix, defeating the purpose of a per-experiment install directory.